### PR TITLE
Add gh command usage message to PR creation template

### DIFF
--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -117,7 +117,7 @@ function claudeCode.config()
 
 				-- Create PR instruction
 				local instruction_parts = {
-					"I'll now use Claude Code to",
+					"I'm going to create a pull request. Please follow these instructions:",
 					"- Create a PR in " .. state.language .. " language",
 					"- Set PR status to " .. (state.draft_mode == "draft" and "draft" or "open"),
 				}
@@ -132,8 +132,6 @@ function claudeCode.config()
 					instruction_parts,
 					"- Please check if .github/PULL_REQUEST_TEMPLATE.md exists and follow that template format if found"
 				)
-
-				table.insert(instruction_parts, "Please create a pull request with the above settings")
 
 				-- Combine the instructions into a single string
 				local instruction_text = table.concat(instruction_parts, "\n")

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -127,6 +127,12 @@ function claudeCode.config()
 					table.insert(instruction_parts, "- With ticket reference: " .. state.ticket)
 				end
 
+				-- Check for PR template
+				table.insert(
+					instruction_parts,
+					"- Please check if .github/PULL_REQUEST_TEMPLATE.md exists and follow that template format if found"
+				)
+
 				table.insert(instruction_parts, "Please create a pull request with the above settings")
 
 				-- Combine the instructions into a single string

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -113,11 +113,9 @@ function claudeCode.config()
 			end, { desc = "Create a PR using Claude Code" })
 
 			function create_pr_with_claude(state)
-				local cmd = "claude"
-
 				-- Create PR instruction
 				local instruction_parts = {
-					"I'm going to create a pull request. Please follow these instructions:",
+					"I'm going to create a pull request. I will use gh command. Please follow these instructions:",
 					"- Create a PR in " .. state.language .. " language",
 					"- Set PR status to " .. (state.draft_mode == "draft" and "draft" or "open"),
 				}


### PR DESCRIPTION
## Summary
- Added a message to indicate that gh command will be used for PR creation in the Claude Code Neovim plugin
- Ensures users are aware that the gh CLI tool is required for PR creation

## Test plan
- Verify the message appears in the instructions when creating a pull request
- Confirm the message is correctly presented to Claude Code
- Test the PR creation workflow to ensure it continues to function correctly

Ticket: https://example.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive workflow for creating pull requests directly within Neovim, allowing users to select PR language, status (draft or open), and add a ticket link.
  - Added a new command and key binding to quickly launch the guided PR creation process using the Claude Code plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->