### PR TITLE
feat: toggle terminal in floating window

### DIFF
--- a/config/nvim/plugins/toggleterm.lua
+++ b/config/nvim/plugins/toggleterm.lua
@@ -6,9 +6,13 @@ function toggleterm.config()
 		version = "*",
 		config = function()
 			require("toggleterm").setup({
-				direction = "vertical",
+				direction = "float",
 				size = 80,
 				start_in_insert = true,
+				float_opts = {
+					border = "curved",
+					winblend = 0,
+				},
 			})
 
 			vim.keymap.set("n", "<leader>tt", ":ToggleTerm<CR>", { desc = "Toggle terminal" })


### PR DESCRIPTION
## Summary
- Changed terminal direction from vertical to floating window
- Added floating window configuration with curved border

## Test plan
1. Open Neovim
2. Press <leader>tt to toggle terminal
3. Verify terminal opens as a floating window with curved border

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the terminal window to open as a floating window with a curved border and no transparency, instead of the previous vertical split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->