### PR TITLE
feat: make orgmode windows float with rounded borders

### DIFF
--- a/config/nvim/plugins/orgmode.lua
+++ b/config/nvim/plugins/orgmode.lua
@@ -7,6 +7,8 @@ function orgmode.config()
 		ft = { "org" },
 		config = function()
 			require("orgmode").setup({
+				win_split_mode = "float",
+				win_border = "rounded",
 				org_agenda_files = {
 					"~/projects/mikinovation/org/personal/**/*",
 					"~/projects/mikinovation/org/work/**/*",


### PR DESCRIPTION
## Summary
- Make orgmode windows appear as floating windows with rounded borders for better visual experience and increased usability

## Test plan
- Open an orgmode file using any of the defined commands
- Verify the window appears as a floating window with rounded borders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated window display for orgmode: now uses floating windows with rounded borders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->