### PR TITLE
docs: translate Japanese comments to English

### DIFF
--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,6 +1,6 @@
 -- luacheck: globals vim
 
--- デフォルトだと相対パスになってしまうので、絶対パスに変更
+-- Change to absolute path instead of the default relative path
 package.path = package.path .. ";" .. vim.fn.expand("~/.config/nvim") .. "/?.lua"
 
 vim.g.mapleader = " "

--- a/config/nvim/plugins/nvim-lspconfig.lua
+++ b/config/nvim/plugins/nvim-lspconfig.lua
@@ -9,7 +9,7 @@ function nvimLspconfig.config()
 			"hrsh7th/cmp-nvim-lsp",
 		},
 		config = function()
-			-- LSPアタッチ時のキーバインド設定
+			-- Keybinding settings for LSP attach
 			vim.api.nvim_create_autocmd("LspAttach", {
 				group = vim.api.nvim_create_augroup("UserLspConfig", { clear = true }),
 				callback = function(event)
@@ -19,12 +19,12 @@ function nvimLspconfig.config()
 					-- Enable completion triggered by <c-x><c-o>
 					vim.bo[bufnr].omnifunc = "v:lua.vim.lsp.omnifunc"
 
-					-- バッファローカルなキーマッピング
+					-- Buffer-local keymappings
 					local map = function(keys, func, desc)
 						vim.keymap.set("n", keys, func, { buffer = bufnr, desc = "LSP: " .. desc })
 					end
 
-					-- よく使う機能のキーマッピング
+					-- Keymappings for commonly used features
 					map("gd", require("telescope.builtin").lsp_definitions, "[G]oto [D]efinition")
 					map("gr", require("telescope.builtin").lsp_references, "[G]oto [R]eferences")
 					map("gI", require("telescope.builtin").lsp_implementations, "[G]oto [I]mplementation")
@@ -56,10 +56,10 @@ function nvimLspconfig.config()
 				end,
 			})
 
-			-- LSPの診断表示設定（サイン、floating windowなど）
+			-- LSP diagnostic display settings (signs, floating windows, etc.)
 			vim.diagnostic.config({
 				virtual_text = {
-					prefix = "●", -- アイコンをカスタマイズ
+					prefix = "●", -- Customize icon
 					severity = {
 						min = vim.diagnostic.severity.WARN,
 					},
@@ -76,18 +76,18 @@ function nvimLspconfig.config()
 				},
 			})
 
-			-- diagnosticサインのカスタマイズ
+			-- Customizing diagnostic signs
 			local signs = { Error = " ", Warn = " ", Hint = " ", Info = " " }
 			for type, icon in pairs(signs) do
 				local hl = "DiagnosticSign" .. type
 				vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = hl })
 			end
 
-			-- capabilities - nvim-cmpとの連携
+			-- capabilities - integration with nvim-cmp
 			local capabilities = vim.lsp.protocol.make_client_capabilities()
 			capabilities = require("cmp_nvim_lsp").default_capabilities(capabilities)
 
-			-- LSPサーバーの設定
+			-- LSP server configuration
 			local lspconfig = require("lspconfig")
 
 			-- Lua

--- a/config/nvim/plugins/telescope.lua
+++ b/config/nvim/plugins/telescope.lua
@@ -132,7 +132,7 @@ function telescope.config()
 				},
 			})
 
-			-- カラースキームとの調和のためのハイライト設定
+			-- Highlight settings for harmonizing with colorscheme
 			vim.api.nvim_create_autocmd("ColorScheme", {
 				pattern = "*",
 				callback = function()
@@ -146,12 +146,12 @@ function telescope.config()
 				end,
 			})
 
-			-- 拡張機能の読み込み
+			-- Load extensions
 			for _, ext in ipairs(telescope_extensions) do
 				pcall(require("telescope").load_extension, ext)
 			end
 
-			-- プロジェクト内を検索するカスタム関数（.gitignoreを尊重）
+			-- Custom function to search within project (respects .gitignore)
 			local function project_files()
 				local opts = {}
 				local ok = pcall(require("telescope.builtin").git_files, opts)
@@ -160,13 +160,13 @@ function telescope.config()
 				end
 			end
 
-			-- カーソルの下の単語でGrep検索
+			-- Grep search for word under cursor
 			local function grep_current_word()
 				local word = vim.fn.expand("<cword>")
 				require("telescope.builtin").grep_string({ search = word })
 			end
 
-			-- ビジュアルモードで選択したテキストを検索
+			-- Search for text selected in visual mode
 			local function grep_visual_selection()
 				local function get_visual_selection()
 					local s_start = vim.fn.getpos("'<")
@@ -186,7 +186,7 @@ function telescope.config()
 				require("telescope.builtin").grep_string({ search = text })
 			end
 
-			-- ファイルの内容を検索して置換
+			-- Search and replace in files
 			local function search_and_replace()
 				local word = vim.fn.expand("<cword>")
 				local search_term = vim.fn.input("Search term: ", word)
@@ -199,13 +199,13 @@ function telescope.config()
 					return
 				end
 
-				-- Telescopeを使用して一致する箇所を表示
+				-- Display matching locations using Telescope
 				require("telescope.builtin").grep_string({
 					search = search_term,
 					prompt_title = "Search: " .. search_term .. " → Replace: " .. replace_term,
 					attach_mappings = function(_, map)
 						map("i", "<CR>", function(prompt_bufnr)
-							local confirmation = vim.fn.input("実行しますか? (y/n): ")
+							local confirmation = vim.fn.input("Execute? (y/n): ")
 							if confirmation:lower() == "y" then
 								vim.cmd("%s/" .. search_term .. "/" .. replace_term .. "/g")
 								require("telescope.actions").close(prompt_bufnr)
@@ -216,7 +216,7 @@ function telescope.config()
 				})
 			end
 
-			-- 基本的なTelescopeキーマッピング
+			-- Basic Telescope keymappings
 			local builtin = require("telescope.builtin")
 			vim.keymap.set("n", "<leader>fh", builtin.help_tags, { desc = "[F]ind [H]elp" })
 			vim.keymap.set("n", "<leader>fk", builtin.keymaps, { desc = "[F]ind [K]eymaps" })
@@ -230,7 +230,7 @@ function telescope.config()
 			vim.keymap.set("n", "<leader>fb", builtin.buffers, { desc = "[F]ind [B]uffers" })
 			vim.keymap.set("n", "<leader>fy", ":Telescope yank_history<CR>", { desc = "[F]ind [Y]ank History" })
 
-			-- 追加のTelescopeキーマッピング
+			-- Additional Telescope keymappings
 			vim.keymap.set("n", "<leader>f/", function()
 				builtin.current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
 					winblend = 10,
@@ -249,10 +249,10 @@ function telescope.config()
 				builtin.find_files({ cwd = vim.fn.stdpath("config") })
 			end, { desc = "[F]ind [N]eovim Files" })
 
-			-- 拡張機能のキーマッピング
+			-- Extension keymappings
 			vim.keymap.set("n", "<leader>fb", ":Telescope file_browser<CR>", { desc = "[F]ile [B]rowser" })
 
-			-- 現在開いているファイルのディレクトリをfile_browserで開く
+			-- Open current file's directory in file_browser
 			vim.keymap.set("n", "<leader>fo", function()
 				require("telescope").extensions.file_browser.file_browser({
 					path = "%:p:h",
@@ -266,7 +266,7 @@ function telescope.config()
 				})
 			end, { desc = "[F]ile Browser - [O]pen Current Directory" })
 
-			-- ホームディレクトリをfile_browserで開く
+			-- Open home directory in file_browser
 			vim.keymap.set("n", "<leader>fH", function()
 				require("telescope").extensions.file_browser.file_browser({
 					path = "~",
@@ -286,12 +286,12 @@ function telescope.config()
 			vim.keymap.set("n", "<leader>fm", ":Telescope media_files<CR>", { desc = "[F]ind [M]edia Files" })
 			vim.keymap.set("n", "<leader>sf", ":Telescope frecency<CR>", { desc = "[S]earch [F]requent Files" })
 
-			-- Gitとの統合
+			-- Git integration
 			vim.keymap.set("n", "<leader>gs", builtin.git_status, { desc = "[G]it [S]tatus" })
 			vim.keymap.set("n", "<leader>gc", builtin.git_commits, { desc = "[G]it [C]ommits" })
 			vim.keymap.set("n", "<leader>gb", builtin.git_branches, { desc = "[G]it [B]ranches" })
 
-			-- カスタム関数のキーマッピング
+			-- Custom function keymappings
 			vim.keymap.set("n", "<leader>pf", project_files, { desc = "[P]roject [F]iles" })
 			vim.keymap.set("n", "<leader>sw", grep_current_word, { desc = "[S]earch Current [W]ord" })
 			vim.keymap.set("v", "<leader>sw", grep_visual_selection, { desc = "[S]earch Selected [W]ord" })


### PR DESCRIPTION
## Summary
- Translated Japanese comments in Neovim configuration files to English
- Improved readability for non-Japanese speakers
- No functional changes to the codebase

## Files Changed
- config/nvim/init.lua
- config/nvim/plugins/nvim-lspconfig.lua
- config/nvim/plugins/telescope.lua

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Translated all comments and user-facing prompt strings from Japanese to English for improved accessibility.
- **Documentation**
  - Updated in-line documentation and prompts to English throughout the configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->