### PR TITLE
Add target branch selection to PR creation flow

### DIFF
--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -85,12 +85,25 @@ function claudeCode.config()
 
 						-- Make sure main branch is at the top
 						table.sort(branches, function(a, b)
+							-- If both are priority branches, maintain alphabetical order between them
+							if (a == "main" or a == "develop") and (b == "main" or b == "develop") then
+								return a < b
+							end
+							-- Main branch comes first
 							if a == "main" then
 								return true
 							end
 							if b == "main" then
 								return false
 							end
+							-- Develop branch comes second
+							if a == "develop" then
+								return true
+							end
+							if b == "develop" then
+								return false
+							end
+							-- Other branches in alphabetical order
 							return a < b
 						end)
 
@@ -207,7 +220,6 @@ function claudeCode.config()
 					end)
 				end)
 			end, { desc = "Create a PR using Claude Code" })
-
 
 			-- Add keymap
 			vim.keymap.set("n", "<leader>cP", ":ClaudeCodeCreatePR<CR>", { desc = "Create a PR using Claude Code" })

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -60,64 +60,53 @@ function claudeCode.config()
 				ticket_required = false,
 			}
 
-			-- Custom command for PR creation
-			vim.api.nvim_create_user_command("ClaudeCodeCreatePR", function()
-				local state = {
-					language = nil,
-					draft_mode = nil,
-					ticket = nil,
-				}
+			-- Function to get GitHub branches
+			local function github_branches(callback)
+				local job = require("plenary.job")
 
-				-- Language selection
-				vim.ui.select(pr_config.languages, {
-					prompt = "Select PR language:",
-					format_item = function(item)
-						return item
-					end,
-				}, function(language)
-					if not language then
-						return
-					end
-					state.language = language
-
-					-- Draft/Open selection
-					vim.ui.select(pr_config.draft_options, {
-						prompt = "Select PR status:",
-						format_item = function(item)
-							return item
-						end,
-					}, function(draft_mode)
-						if not draft_mode then
+				job:new({
+					command = "gh",
+					args = { "api", "repos/{owner}/{repo}/branches" },
+					on_exit = function(j, return_val)
+						if return_val ~= 0 then
+							vim.notify("Failed to get branches", vim.log.levels.ERROR)
+							callback({ "main" }) -- Fallback to main branch only
 							return
 						end
-						state.draft_mode = draft_mode
 
-						-- Ticket link input (optional)
-						if pr_config.ticket_required then
-							vim.ui.input({
-								prompt = "Enter ticket link:",
-							}, function(ticket)
-								state.ticket = ticket or ""
-								create_pr_with_claude(state)
-							end)
-						else
-							vim.ui.input({
-								prompt = "Enter ticket link (optional):",
-							}, function(ticket)
-								state.ticket = ticket or ""
-								create_pr_with_claude(state)
-							end)
+						local result = table.concat(j:result(), "")
+						local branches = {}
+
+						-- Extract branch names from JSON response
+						-- Simple pattern matching to extract names
+						for name in result:gmatch('"name":"([^"]+)"') do
+							table.insert(branches, name)
 						end
-					end)
-				end)
-			end, { desc = "Create a PR using Claude Code" })
 
-			function create_pr_with_claude(state)
+						-- Make sure main branch is at the top
+						table.sort(branches, function(a, b)
+							if a == "main" then
+								return true
+							end
+							if b == "main" then
+								return false
+							end
+							return a < b
+						end)
+
+						callback(branches)
+					end,
+				}):start()
+			end
+
+			-- Helper function for creating PR with Claude
+			local function create_pr_with_claude(state)
 				-- Create PR instruction
 				local instruction_parts = {
 					"I'm going to create a pull request. I will use gh command. Please follow these instructions:",
 					"- Create a PR in " .. state.language .. " language",
 					"- Set PR status to " .. (state.draft_mode == "draft" and "draft" or "open"),
+					"- Target branch should be " .. state.target_branch,
 				}
 
 				-- Add ticket information if available
@@ -150,6 +139,75 @@ function claudeCode.config()
 					end
 				end, 2000) -- Reduced delay to 1 second
 			end
+
+			-- Custom command for PR creation
+			vim.api.nvim_create_user_command("ClaudeCodeCreatePR", function()
+				local state = {
+					language = nil,
+					draft_mode = nil,
+					ticket = nil,
+					target_branch = nil,
+				}
+
+				-- Language selection
+				vim.ui.select(pr_config.languages, {
+					prompt = "Select PR language:",
+					format_item = function(item)
+						return item
+					end,
+				}, function(language)
+					if not language then
+						return
+					end
+					state.language = language
+
+					-- Draft/Open selection
+					vim.ui.select(pr_config.draft_options, {
+						prompt = "Select PR status:",
+						format_item = function(item)
+							return item
+						end,
+					}, function(draft_mode)
+						if not draft_mode then
+							return
+						end
+						state.draft_mode = draft_mode
+
+						-- Target branch selection
+						github_branches(function(branches)
+							vim.ui.select(branches, {
+								prompt = "Select target branch:",
+								format_item = function(item)
+									return item
+								end,
+							}, function(target_branch)
+								if not target_branch then
+									return
+								end
+								state.target_branch = target_branch
+
+								-- Ticket link input (optional)
+								if pr_config.ticket_required then
+									vim.ui.input({
+										prompt = "Enter ticket link:",
+									}, function(ticket)
+										state.ticket = ticket or ""
+										create_pr_with_claude(state)
+									end)
+								else
+									vim.ui.input({
+										prompt = "Enter ticket link (optional):",
+									}, function(ticket)
+										state.ticket = ticket or ""
+										create_pr_with_claude(state)
+									end)
+								end
+							end)
+						end)
+					end)
+				end)
+			end, { desc = "Create a PR using Claude Code" })
+
 
 			-- Add keymap
 			vim.keymap.set("n", "<leader>cP", ":ClaudeCodeCreatePR<CR>", { desc = "Create a PR using Claude Code" })

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -77,10 +77,18 @@ function claudeCode.config()
 						local result = table.concat(j:result(), "")
 						local branches = {}
 
-						-- Extract branch names from JSON response
-						-- Simple pattern matching to extract names
-						for name in result:gmatch('"name":"([^"]+)"') do
-							table.insert(branches, name)
+						-- Parse JSON response properly using vim.fn.json_decode
+						local ok, decoded = pcall(vim.fn.json_decode, result)
+						if ok and decoded then
+							for _, branch in ipairs(decoded) do
+								if branch.name then
+									table.insert(branches, branch.name)
+								end
+							end
+						else
+							vim.notify("Failed to parse branches JSON", vim.log.levels.WARN)
+							callback({ "main" }) -- Fallback to main branch only
+							return
 						end
 
 						-- Make sure main branch is at the top


### PR DESCRIPTION
## Summary
Added target branch selection feature to the PR creation flow.
Now both `main` and `develop` branches will be prioritized at the top of the selection list.

### Improvements
- Using `vim.fn.json_decode` for proper parsing of the GitHub API response
- Priority sorting for both `main` and `develop` branches

## Test plan
- [x] Verify that target branches can be correctly selected when creating a PR
- [x] Verify that PRs are created correctly to the selected branch
- [x] Verify that `main` and `develop` branches appear at the top of the selection list