### PR TITLE
feat: add linking for claude commands directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ NVIM_CONFIG_DIR="$HOME/.config/nvim"
 WEZTERM_CONFIG_DIR="$HOME"
 SHELDON_CONFIG_DIR="$HOME/.config/sheldon"
 ZSH_CONFIG_DIR="$HOME"
+CLAUDE_DIR="$HOME/.claude"
 
 link_nvim_config() {
   if [ ! -d "$NVIM_CONFIG_DIR" ]; then
@@ -41,6 +42,16 @@ link_zsh_config() {
   ln -snfv "$DOTFILES_DIR"/config/zsh/.p10k.zsh "$HOME/.p10k.zsh"
 }
 
+link_claude_config() {
+  if [ ! -d "$CLAUDE_DIR/commands" ]; then
+    mkdir -p "$CLAUDE_DIR/commands"
+  fi
+
+  for file in "$DOTFILES_DIR"/claude/commands/*; do
+    ln -snfv "$file" "$CLAUDE_DIR/commands/$(basename "$file")"
+  done
+}
+
 main() {
   echo "Start setup dotfiles..."
 
@@ -60,6 +71,9 @@ main() {
 
   link_zsh_config
   echo "Linking zsh config done."
+
+  link_claude_config
+  echo "Linking claude commands done."
 
   echo "Setup dotfiles done."
 }


### PR DESCRIPTION
## Summary
- Add .claude directory to store Claude-related files
- Create linking functionality for claude/commands directory
- Link command files during setup process

## Test plan
- Run setup.sh
- Verify that claude command files are properly linked to ~/.claude/commands/