### PR TITLE
fix: resolve linting issues in Neovim config

### DIFF
--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -10,7 +10,8 @@ function claudeCode.config()
 			require("claude-code").setup({
 				-- Terminal window settings
 				window = {
-					split_ratio = 0.5, -- Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
+					split_ratio = 0.5, -- Percentage of screen for the terminal window
+					-- (height for horizontal, width for vertical splits)
 					position = "vertical", -- Position of the window: "botright", "topleft", "vertical", "rightbelow vsplit", etc.
 					enter_insert = true, -- Whether to enter insert mode when opening Claude Code
 					hide_numbers = true, -- Hide line numbers in the terminal window

--- a/config/nvim/plugins/none-ls.lua
+++ b/config/nvim/plugins/none-ls.lua
@@ -31,8 +31,8 @@ function noneLs.config()
 							callback = function()
 								vim.lsp.buf.format({
 									bufnr = bufnr,
-									filter = function(client)
-										return client.name == "null-ls"
+									filter = function(lsp_client)
+										return lsp_client.name == "null-ls"
 									end,
 								})
 							end,
@@ -41,8 +41,8 @@ function noneLs.config()
 						vim.keymap.set("n", "<leader>nf", function()
 							vim.lsp.buf.format({
 								bufnr = bufnr,
-								filter = function(client)
-									return client.name == "null-ls"
+								filter = function(lsp_client)
+									return lsp_client.name == "null-ls"
 								end,
 							})
 						end, { buffer = bufnr, desc = "Format current buffer with none-ls" })

--- a/config/nvim/plugins/nvim-cmp.lua
+++ b/config/nvim/plugins/nvim-cmp.lua
@@ -28,11 +28,6 @@ function nvimCmp.config()
 
 			require("luasnip.loaders.from_vscode").lazy_load()
 
-			local check_backspace = function()
-				local col = vim.fn.col(".") - 1
-				return col == 0 or vim.fn.getline("."):sub(col, col):match("%s") ~= nil
-			end
-
 			local has_words_before = function()
 				if vim.api.nvim_buf_get_option(0, "buftype") == "prompt" then
 					return false

--- a/config/nvim/plugins/nvim-lspconfig.lua
+++ b/config/nvim/plugins/nvim-lspconfig.lua
@@ -132,7 +132,8 @@ function nvimLspconfig.config()
 					plugins = {
 						{
 							name = "@vue/typescript-plugin",
-							location = "/home/mikinovation/.local/share/fnm/node-versions/v22.13.0/installation/lib/node_modules/@vue/typescript-plugin",
+							location = "/home/mikinovation/.local/share/fnm/node-versions/v22.13.0/installation/lib/"
+								.. "node_modules/@vue/typescript-plugin",
 							languages = { "javascript", "typescript", "vue" },
 						},
 					},

--- a/config/nvim/plugins/nvim-tree.lua
+++ b/config/nvim/plugins/nvim-tree.lua
@@ -71,7 +71,8 @@ function nvimTree.config()
 			vim.keymap.set(
 				"n",
 				"<leader>ef",
-				"<cmd>lua require('nvim-tree.api').tree.toggle({path=nil, current_window=false, find_file=false, update_root=false, focus=true})<CR>",
+				"<cmd>lua require('nvim-tree.api').tree.toggle({path=nil, current_window=false, "
+					.. "find_file=false, update_root=false, focus=true})<CR>",
 				{ desc = "Toggle floating file explorer" }
 			)
 			vim.keymap.set("n", "<leader>ec", "<cmd>NvimTreeFindFile<CR>", { desc = "Reveal current file in tree" })

--- a/config/nvim/plugins/pathtool.lua
+++ b/config/nvim/plugins/pathtool.lua
@@ -3,7 +3,8 @@ local pathtool = {}
 function pathtool.config()
 	return {
 		"mikinovation/pathtool.nvim",
-		-- renovate: datasource=github-releases depName=mikinovation/pathtool.nvim commit=a4a97ffee7b105451c5925beb444847cdc468b
+		-- renovate: datasource=github-releases depName=mikinovation/pathtool.nvim
+	-- commit=a4a97ffee7b105451c5925beb444847cdc468b
 		commit = "94a4a97ffee7b105451c5925beb444847cdc468b",
 		config = function()
 			require("pathtool").setup()


### PR DESCRIPTION
## Summary
- Fixed line length issues in multiple Neovim configuration files
- Fixed variable shadowing in none-ls.lua
- Removed unused function in nvim-cmp.lua
- Fixed trailing whitespace issues

## Test plan
1. Run the linting script to verify all issues are resolved: `sh ./scripts/lint.sh`
2. The script should report 0 warnings and 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved code readability by reformatting comments and string concatenations in multiple plugin configurations.
  - Enhanced clarity in parameter naming within filter functions.
  - Removed an unused helper function from the completion configuration.
  - Reformatted key mapping command strings for better readability.
- **Chores**
  - Updated comment formatting and removed unnecessary trailing newlines in various configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->