### PR TITLE
WSL clipboard integration for Neovim and ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ sudo luarocks install luacheck
 npm install -g typescript typescript-language-server @tailwindcss/language-server 
 ```
 
+### win32yank (for WSL)
+
+For clipboard integration between WSL and Windows, install win32yank:
+
+```bash
+# Create bin directory if it doesn't exist
+mkdir -p ~/.local/bin
+
+# Download win32yank
+curl -sLo /tmp/win32yank.zip https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x64.zip
+
+# Extract executable
+unzip -p /tmp/win32yank.zip win32yank.exe > ~/.local/bin/win32yank.exe
+
+# Make executable
+chmod +x ~/.local/bin/win32yank.exe
+
+# Add to PATH if not already included
+echo 'export PATH=$PATH:~/.local/bin' >> ~/.zshrc
+
+# Clean up
+rm /tmp/win32yank.zip
+```
+
+Make sure `~/.local/bin` is in your PATH to use clipboard features in Neovim and ZSH.
+
 ### luaformatter
 
 formatter for lua

--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -9,6 +9,9 @@ end ---@diagnostic disable-next-line: undefined-field
 
 vim.opt.rtp:prepend(lazypath)
 
+-- Load clipboard configuration early
+require("plugins.clipboard").config()
+
 require("lazy").setup({
 	require("plugins.avante").config(),
 	require("plugins.comment").config(),

--- a/config/nvim/plugins/clipboard.lua
+++ b/config/nvim/plugins/clipboard.lua
@@ -1,0 +1,23 @@
+return {
+	-- Clipboard configuration for WSL
+	config = function()
+		-- Check if we're in a WSL environment
+		local is_wsl = vim.fn.has("wsl") == 1
+
+		if is_wsl then
+			-- Configure clipboard for WSL
+			vim.g.clipboard = {
+				name = "win32yank",
+				copy = {
+					["+"] = "win32yank.exe -i --crlf",
+					["*"] = "win32yank.exe -i --crlf",
+				},
+				paste = {
+					["+"] = "win32yank.exe -o --lf",
+					["*"] = "win32yank.exe -o --lf",
+				},
+				cache_enabled = 0,
+			}
+		end
+	end,
+}

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -22,5 +22,8 @@ if [ -d "$FNM_PATH" ]; then
 fi
 eval "$(fnm env --use-on-cd --shell zsh)"
 
+# Load WSL specific configurations if on WSL
+[[ -f ~/dotfiles/config/zsh/plugins/wsl.zsh ]] && source ~/dotfiles/config/zsh/plugins/wsl.zsh
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh

--- a/config/zsh/plugins/wsl.zsh
+++ b/config/zsh/plugins/wsl.zsh
@@ -1,0 +1,7 @@
+# WSL2 clipboard configuration
+if grep -q microsoft /proc/version; then
+  # Using win32yank from ~/.local/bin
+  # Alternative method using PowerShell
+  alias pbcopy="clip.exe"
+  alias pbpaste="powershell.exe -command 'Get-Clipboard' | tr -d '\r'"
+fi


### PR DESCRIPTION
## Summary
- Add clipboard integration for Windows Subsystem for Linux (WSL) environment
- Configure Neovim to use win32yank.exe for clipboard operations in WSL
- Add ZSH aliases for clipboard operations (pbcopy/pbpaste) in WSL

## Changes
- Create new plugin file for Neovim clipboard configuration
- Update plugins.lua to load clipboard configuration early
- Add WSL detection and clipboard configuration for ZSH
- Create WSL-specific plugin file for ZSH

## Testing
- Tested copy/paste functionality between WSL and Windows
- Verified clipboard operations in Neovim
- Confirmed ZSH aliases work correctly for command-line clipboard operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic clipboard integration for Neovim and Zsh when running in Windows Subsystem for Linux (WSL), enabling seamless copy and paste between WSL and Windows.
  - Introduced conditional loading of WSL-specific configuration in Zsh for enhanced environment compatibility.

- **Chores**
  - Refined configuration loading order to ensure clipboard settings are applied before other plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->