### PR TITLE
feat: add nvim-colorizer plugin for color highlighting

### DIFF
--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -30,6 +30,7 @@ require("lazy").setup({
 	require("plugins.nvim-autopairs").config(),
 	require("plugins.nvim-bqf").config(),
 	require("plugins.nvim-cmp").config(),
+	require("plugins.nvim-colorizer").config(),
 	require("plugins.nvim-context-vt").config(),
 	require("plugins.nvim-dap").config(),
 	require("plugins.nvim-notify").config(),

--- a/config/nvim/plugins/nvim-colorizer.lua
+++ b/config/nvim/plugins/nvim-colorizer.lua
@@ -1,0 +1,12 @@
+local nvimColorizer = {}
+
+function nvimColorizer.config()
+	return {
+		"norcalli/nvim-colorizer.lua",
+		config = function()
+			require("colorizer").setup()
+		end,
+	}
+end
+
+return nvimColorizer


### PR DESCRIPTION
## Summary
- Add nvim-colorizer.lua plugin for automatic color code highlighting in Neovim
- Implemented following project code style conventions

## Test plan
- Run setup.sh to link configuration
- Open files with color codes (CSS, HTML, etc.) to verify colors are highlighted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for color highlighting in Neovim, enabling automatic color visualization within files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->