### PR TITLE
Add nvim-dbee database client plugin

### DIFF
--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -33,6 +33,7 @@ require("lazy").setup({
 	require("plugins.nvim-colorizer").config(),
 	require("plugins.nvim-context-vt").config(),
 	require("plugins.nvim-dap").config(),
+	require("plugins.nvim-dbee").config(),
 	require("plugins.nvim-notify").config(),
 	require("plugins.nvim-treesitter-context").config(),
 	require("plugins.nvim-treesitter").config(),

--- a/config/nvim/plugins/nvim-dbee.lua
+++ b/config/nvim/plugins/nvim-dbee.lua
@@ -12,8 +12,7 @@ function nvimDbee.config()
 		config = function()
 			require("dbee").setup({
 				sources = {
-					require("dbee.sources").FileSource:new(vim.fn.stdpath("cache") ..
-					"/dbee/persistence.json"),
+					require("dbee.sources").FileSource:new(vim.fn.stdpath("cache") .. "/dbee/persistence.json"),
 				},
 			})
 

--- a/config/nvim/plugins/nvim-dbee.lua
+++ b/config/nvim/plugins/nvim-dbee.lua
@@ -1,0 +1,25 @@
+local nvimDbee = {}
+
+function nvimDbee.config()
+	return {
+		"kndndrj/nvim-dbee",
+		dependencies = {
+			"MunifTanjim/nui.nvim",
+		},
+		build = function()
+			require("dbee").install()
+		end,
+		config = function()
+			require("dbee").setup({
+				sources = {
+					require("dbee.sources").FileSource:new(vim.fn.stdpath("cache") ..
+					"/dbee/persistence.json"),
+				},
+			})
+
+			vim.keymap.set("n", "<leader>db", "<cmd>Dbee toggle<CR>", { desc = "Toggle DBee" })
+		end,
+	}
+end
+
+return nvimDbee


### PR DESCRIPTION
## Summary
- Add nvim-dbee plugin to provide a database client integrated within Neovim
- Configure with file persistence to save connection information
- Add keybinding '<leader>db' to toggle the client interface

## Test plan
1. Run './setup.sh' to apply configuration
2. Open Neovim and press '<leader>db' to open DBee
3. Verify database connections can be added and saved
4. Test query execution with Enter key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added integration for the nvim-dbee plugin, enabling database management within Neovim.
	- Introduced a keyboard shortcut (<leader>db) to quickly toggle the database interface.
- **Chores**
	- Updated plugin configuration to include nvim-dbee and its dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->