### PR TITLE
Fix: Update rest.nvim keymap for better UX

### DIFF
--- a/config/nvim/plugins/rest.lua
+++ b/config/nvim/plugins/rest.lua
@@ -11,9 +11,7 @@ function rest.config()
 			end,
 		},
 		config = function()
-			vim.keymap.set("n", "<leader>rr", "<Plug>RestNvim", { desc = "Run HTTP request under cursor" })
-			vim.keymap.set("n", "<leader>rp", "<Plug>RestNvimPreview", { desc = "Preview HTTP request under cursor" })
-			vim.keymap.set("n", "<leader>rl", "<Plug>RestNvimLast", { desc = "Re-run last HTTP request" })
+			vim.keymap.set("n", "<leader>rr", "<cmd>Rest run<CR>", { desc = "Select REST environment file" })
 		end,
 	}
 end


### PR DESCRIPTION
## Summary
- Updated rest.nvim keymap to use a more intuitive single command
- Replaced multiple specific keymaps with a single command that opens the command selection menu

## Test plan
- Open a HTTP request file (.http or .rest)
- Press <leader>rr to verify the REST command menu opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified key mappings for REST requests, replacing multiple shortcuts with a single keybinding to select the REST environment file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->