### PR TITLE
Add gitlinker.nvim for shareable git permalinks

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -15,6 +15,7 @@
   "fidget.nvim": { "branch": "main", "commit": "d9ba6b7bfe29b3119a610892af67602641da778e" },
   "friendly-snippets": { "branch": "main", "commit": "efff286dd74c22f731cdec26a70b46e5b203c619" },
   "git-conflict.nvim": { "branch": "main", "commit": "bfd9fe6fba9a161fc199771d85996236a0d0faad" },
+  "gitlinker.nvim": { "branch": "master", "commit": "cc59f732f3d043b626c8702cb725c82e54d35c25" },
   "gitsigns.nvim": { "branch": "main", "commit": "1796c7cedfe7e5dd20096c5d7b8b753d8f8d22eb" },
   "indent-blankline.nvim": { "branch": "master", "commit": "005b56001b2cb30bfa61b7986bc50657816ba4ba" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },

--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -17,6 +17,7 @@ require("lazy").setup({
 	require("plugins.copilot").config(),
 	require("plugins.dropbar").config(),
 	require("plugins.git-conflict").config(),
+	require("plugins.gitlinker").config(),
 	require("plugins.gitsigns").config(),
 	require("plugins.indent-blankline").config(),
 	require("plugins.lazydev").config(),

--- a/config/nvim/plugins/gitlinker.lua
+++ b/config/nvim/plugins/gitlinker.lua
@@ -1,0 +1,26 @@
+local gitlinker = {}
+
+function gitlinker.config()
+	return {
+		"ruifm/gitlinker.nvim",
+		dependencies = { "nvim-lua/plenary.nvim" },
+		config = function()
+			require("gitlinker").setup({
+				opts = {
+					-- remote: nil (automatically find the remote) or a specific string
+					-- remote = "origin",
+					-- adds current line on normal mode
+					add_current_line_on_normal_mode = true,
+					-- callback for what to do with the url
+					action_callback = require("gitlinker.actions").copy_to_clipboard,
+					-- print the url after action
+					print_url = true,
+				},
+				-- default mapping to call url generation with action_callback
+				mappings = "<leader>gy",
+			})
+		end,
+	}
+end
+
+return gitlinker


### PR DESCRIPTION
## Summary
- Add gitlinker.nvim plugin for creating shareable git permalinks
- Configure plugin in plugins.lua
- Update lock file with new dependency

## Changes
This PR adds the gitlinker.nvim plugin which allows users to easily create shareable git permalinks to specific lines of code. The plugin is registered in plugins.lua and the lock file has been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added integration for generating and copying GitHub/GitLab/etc. links to lines or selections in files directly from Neovim.
	- Introduced a new key mapping (<leader>gy) to quickly generate and copy repository URLs to the clipboard.
	- Automatically detects remote repositories and includes line numbers in generated links.
	- Displays the generated URL after copying for quick reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->