### PR TITLE
Add open-browser.vim plugin for opening URLs in browser

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -51,6 +51,7 @@
   "nvim-ts-context-commentstring": { "branch": "main", "commit": "1b212c2eee76d787bbea6aa5e92a2b534e7b4f8f" },
   "nvim_context_vt": { "branch": "master", "commit": "10e13ec47a9bb341192d893e58cf91c61cde4935" },
   "octo.nvim": { "branch": "master", "commit": "974d2247b64535bedbbdbb7bec29dfa4e2395037" },
+  "open-browser.vim": { "branch": "master", "commit": "7d4c1d8198e889d513a030b5a83faa07606bac27" },
   "orgmode": { "branch": "master", "commit": "15d66ead1285d99f8a21c4ef4874ac62e9320fe6" },
   "package-info.nvim": { "branch": "master", "commit": "4f1b8287dde221153ec9f2acd46e8237d2d0881e" },
   "pathtool.nvim": { "branch": "main", "commit": "dfed489d1e6a628ca73ceafbdfa30e5d55ca481b" },

--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -60,6 +60,7 @@ require("lazy").setup({
 	require("plugins.which-key").config(),
 	require("plugins.yanky").config(),
 	require("plugins.claude-code").config(),
+	require("plugins.open-browser").config(),
 }, {
 	ui = {
 		icons = vim.g.have_nerd_font and {} or {

--- a/config/nvim/plugins/open-browser.lua
+++ b/config/nvim/plugins/open-browser.lua
@@ -1,0 +1,14 @@
+local openBrowser = {}
+
+function openBrowser.config()
+	return {
+		"tyru/open-browser.vim",
+		config = function()
+			-- Set keymaps for opening URLs
+			vim.keymap.set("n", "gx", "<Plug>(openbrowser-smart-search)", { desc = "Open URL under cursor" })
+			vim.keymap.set("v", "gx", "<Plug>(openbrowser-smart-search)", { desc = "Open selected URL" })
+		end,
+	}
+end
+
+return openBrowser


### PR DESCRIPTION
## Summary
- Add open-browser.vim plugin to allow opening URLs directly from Neovim
- Configure keymaps to use gx in normal and visual modes for opening URLs

## Test plan
- Verify the plugin loads correctly when starting Neovim
- Test gx keybinding on a URL to ensure it opens in the default browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added integration for the "open-browser" plugin in Neovim.
  - Introduced new keyboard shortcuts: Pressing `gx` in normal or visual mode now opens the URL under the cursor or in the selected text directly in your browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->