### PR TITLE
feat: add ClaudeCodeCommit command with language selection

### DIFF
--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -54,12 +54,46 @@ function claudeCode.config()
 				},
 			})
 
-			-- Custom configuration for PR creation
-			local pr_config = {
+			-- Custom configuration for PR creation and commit
+			local claude_config = {
 				languages = { "ja", "en" },
 				draft_options = { "draft", "open" },
 				ticket_required = false,
 			}
+
+			-- Commit creation helper function
+			local commit_with_claude = function(state)
+				-- Create commit instruction
+				local instruction_parts = {
+					"I'm going to create a commit message. Please follow these instructions:",
+					"- Create a commit message in " .. state.language .. " language",
+					"- Follow conventional commits format (e.g., `feat:`, `fix:`, `chore:`)",
+				}
+
+				local instruction_text = table.concat(instruction_parts, "\n")
+				local claude_code_module = require("claude-code")
+				local bufnr = claude_code_module.claude_code.bufnr
+				local window_exists = false
+
+				if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+					local win_ids = vim.fn.win_findbuf(bufnr)
+					window_exists = #win_ids > 0
+				end
+
+				if not window_exists then
+					vim.cmd("ClaudeCode")
+				end
+
+				vim.defer_fn(function()
+					local updated_bufnr = claude_code_module.claude_code.bufnr
+					if updated_bufnr and vim.api.nvim_buf_is_valid(updated_bufnr) then
+						local chan_id = vim.api.nvim_buf_get_var(updated_bufnr, "terminal_job_id")
+						if chan_id then
+							vim.api.nvim_chan_send(chan_id, instruction_text)
+						end
+					end
+				end, window_exists and 100 or 1000) -- Shorter delay if window already exists
+			end
 
 			-- PR creation helper function (defined before it's used)
 			local create_pr_with_claude = function(state)
@@ -142,7 +176,7 @@ function claudeCode.config()
 				}
 
 				-- Language selection
-				vim.ui.select(pr_config.languages, {
+				vim.ui.select(claude_config.languages, {
 					prompt = "Select PR language:",
 					format_item = function(item)
 						return item
@@ -154,7 +188,7 @@ function claudeCode.config()
 					state.language = language
 
 					-- Draft/Open selection
-					vim.ui.select(pr_config.draft_options, {
+					vim.ui.select(claude_config.draft_options, {
 						prompt = "Select PR status:",
 						format_item = function(item)
 							return item
@@ -166,7 +200,7 @@ function claudeCode.config()
 						state.draft_mode = draft_mode
 
 						-- Ticket link input (optional)
-						if pr_config.ticket_required then
+						if claude_config.ticket_required then
 							vim.ui.input({
 								prompt = "Enter ticket link:",
 							}, function(ticket)
@@ -185,7 +219,34 @@ function claudeCode.config()
 				end)
 			end, { desc = "Create a PR using Claude Code" })
 
+			-- Create :ClaudeCodeCommit command
+			vim.api.nvim_create_user_command("ClaudeCodeCommit", function()
+				local state = {
+					language = nil,
+				}
+
+				-- Language selection
+				vim.ui.select(claude_config.languages, {
+					prompt = "Select commit language:",
+					format_item = function(item)
+						return item
+					end,
+				}, function(language)
+					if not language then
+						return
+					end
+					state.language = language
+					commit_with_claude(state)
+				end)
+			end, { desc = "Create a commit message using Claude Code" })
+
 			vim.keymap.set("n", "<leader>cP", ":ClaudeCodeCreatePR<CR>", { desc = "Create a PR using Claude Code" })
+			vim.keymap.set(
+				"n",
+				"<leader>cM",
+				":ClaudeCodeCommit<CR>",
+				{ desc = "Create a commit message using Claude Code" }
+			)
 		end,
 	}
 end


### PR DESCRIPTION
## Linked issue
Closes #165

## Description
This PR adds a new ClaudeCodeCommit command that allows users to:
- Create Git commit messages using Claude Code
- Select language (Japanese or English) for the commit message
- Uses the same language selection UI as ClaudeCodeCreatePR
- Adds a convenient keymap <leader>cM to trigger the command

These changes follow the same pattern as the existing ClaudeCodeCreatePR functionality, providing a consistent user experience for Git operations with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command to generate commit messages with Claude Code, supporting language selection and conventional commit formats.
  - Introduced a keyboard shortcut (<leader>cM) to quickly trigger commit message generation.
- **Improvements**
  - Unified configuration for both PR creation and commit message generation, streamlining user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->