### PR TITLE
feat: add pomo.nvim plugin for pomodoro timer

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -56,6 +56,7 @@
   "package-info.nvim": { "branch": "master", "commit": "4f1b8287dde221153ec9f2acd46e8237d2d0881e" },
   "pathtool.nvim": { "branch": "main", "commit": "dfed489d1e6a628ca73ceafbdfa30e5d55ca481b" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
+  "pomo.nvim": { "branch": "main", "commit": "7e06e5221d8d1e596a0ab29dd4d7fcee5f3cd05a" },
   "quick-scope": { "branch": "master", "commit": "f2b6043e04d9ef05205c8953e389304a4c1946f2" },
   "rest.nvim": { "branch": "main", "commit": "2ded89dbda1fd3c1430685ffadf2df8beb28336d" },
   "sqlite.lua": { "branch": "master", "commit": "50092d60feb242602d7578398c6eb53b4a8ffe7b" },

--- a/config/nvim/plugins.lua
+++ b/config/nvim/plugins.lua
@@ -44,6 +44,7 @@ require("lazy").setup({
 	require("plugins.orgmode").config(),
 	require("plugins.package-info").config(),
 	require("plugins.pathtool").config(),
+	require("plugins.pomo").config(),
 	require("plugins.rest").config(),
 	require("plugins.telescope").config(),
 	require("plugins.todo-comments").config(),

--- a/config/nvim/plugins/pomo.lua
+++ b/config/nvim/plugins/pomo.lua
@@ -1,0 +1,42 @@
+local pomo = {}
+
+function pomo.config()
+	return {
+		"epwalsh/pomo.nvim",
+		version = "*",
+		lazy = false,
+		dependencies = {
+			"rcarriga/nvim-notify",
+		},
+		opts = {
+			sessions = {
+				pomodoro = {
+					{ name = "Work", duration = "25m" },
+					{ name = "Short Break", duration = "5m" },
+					{ name = "Work", duration = "25m" },
+					{ name = "Short Break", duration = "5m" },
+					{ name = "Work", duration = "25m" },
+					{ name = "Short Break", duration = "5m" },
+					{ name = "Work", duration = "25m" },
+					{ name = "Long Break", duration = "15m" },
+				},
+			},
+		},
+		config = function(_, opts)
+			require("pomo").setup(opts)
+
+			vim.keymap.set("n", "<leader>ps", ":TimerSession pomodoro<CR>", { desc = "Start pomodoro session" })
+			vim.keymap.set("n", "<leader>pt", ":TimerStop<CR>", { desc = "Stop current timer" })
+
+			-- Ask to start pomodoro session on startup
+			vim.schedule(function()
+				local choice = vim.fn.confirm("Start pomodoro session?", "&Yes\n&No", 1)
+				if choice == 1 then
+					vim.cmd("TimerSession pomodoro")
+				end
+			end)
+		end,
+	}
+end
+
+return pomo


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #181

### 📚 Description

This PR adds the pomo.nvim plugin to provide pomodoro timer functionality in Neovim. The implementation includes:

- **Plugin Configuration**: Added pomo.nvim with standard pomodoro session configuration (25m work / 5m short break / 15m long break cycle)
- **Keybindings**: Added convenient keymaps for starting (`<leader>ps`) and stopping (`<leader>pt`) timer sessions  
- **User Experience**: Includes startup prompt to optionally begin a pomodoro session when opening Neovim
- **Integration**: Properly integrates with existing nvim-notify for timer notifications

The plugin helps improve productivity by implementing the proven pomodoro technique directly within the development environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Pomodoro timer functionality, allowing users to manage work and break intervals directly within Neovim.
  - Added convenient key mappings to start and stop Pomodoro sessions.
  - Users are now prompted on startup to begin a Pomodoro session, streamlining workflow initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->