### PR TITLE
feat: add ClaudeCodeCreateBranch command for automated branch creation

### DIFF
--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -291,6 +291,33 @@ function claudeCode.config()
 				select_base_branch({}, run_push_with_claude)
 			end, { desc = "Push changes using Claude Code" })
 
+			local function build_create_branch_instruction(state)
+				local parts = {
+					"I'm going to create a new git branch. Please follow these instructions:",
+					"- Ticket title: " .. state.title,
+					"- Generate an appropriate branch name based on the ticket title",
+					"- Use conventional branch naming (e.g., feature/, fix/, chore/)",
+				}
+				return table.concat(parts, "\n")
+			end
+
+			local function run_create_branch_with_claude(state)
+				send_to_claude(build_create_branch_instruction(state))
+			end
+
+			vim.api.nvim_create_user_command("ClaudeCodeCreateBranch", function()
+				vim.ui.input({
+					prompt = "Enter ticket title:",
+				}, function(title)
+					if not title or title == "" then
+						vim.notify("Branch creation cancelled", vim.log.levels.INFO)
+						return
+					end
+
+					run_create_branch_with_claude({ title = title })
+				end)
+			end, { desc = "Create a git branch using Claude Code" })
+
 			-- Keymap
 			vim.keymap.set("n", "<leader>cP", ":ClaudeCodeCreatePR<CR>", { desc = "Create a PR using Claude Code" })
 			vim.keymap.set("n", "<leader>cM", ":ClaudeCodeCommit<CR>", { desc = "Create a commit using Claude Code" })
@@ -301,6 +328,12 @@ function claudeCode.config()
 				{ desc = "Create a GitHub issue using Claude Code" }
 			)
 			vim.keymap.set("n", "<leader>cS", ":ClaudeCodePush<CR>", { desc = "Push changes using Claude Code" })
+			vim.keymap.set(
+				"n",
+				"<leader>cB",
+				":ClaudeCodeCreateBranch<CR>",
+				{ desc = "Create a git branch using Claude Code" }
+			)
 		end,
 	}
 end


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #195

### 📚 Description

This PR adds a new command to the Claude Code Neovim plugin that automates the git branch creation workflow. 

The `ClaudeCodeCreateBranch` command:
- Prompts the user for a ticket title
- Sends instructions to Claude Code to generate an appropriate branch name
- Follows conventional branch naming patterns (feature/, fix/, chore/)

This enhancement streamlines the development workflow by eliminating the need to manually create branch names based on ticket titles.

## Changes
- Added `ClaudeCodeCreateBranch` command
- Added keymap `<leader>cB` to trigger the command
- Integrated with the existing Claude Code infrastructure

## Test plan
- [x] Command prompts for ticket title
- [x] Command sends appropriate instructions to Claude Code
- [x] Keymap is properly registered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command to create git branches by providing a ticket title, with branch names generated according to conventional patterns.
  - Introduced a new keyboard shortcut (<leader>cB) to quickly trigger the branch creation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->