### PR TITLE
chore: remove hard-coded commit IDs from plugin configurations

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -1,7 +1,7 @@
 {
   "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
   "FixCursorHold.nvim": { "branch": "master", "commit": "1900f89dc17c603eec29960f57c00bd9ae696495" },
-  "LuaSnip": { "branch": "master", "commit": "03c8e67eb7293c404845b3982db895d59c0d1538" },
+  "LuaSnip": { "branch": "master", "commit": "de10d8414235b0a8cabfeba60d07c24304e71f5c" },
   "claude-code.nvim": { "branch": "main", "commit": "91b38f289c9b1f08007a0443020ed97bb7539ebe" },
   "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
   "cmp-cmdline": { "branch": "main", "commit": "d250c63aa13ead745e3a40f61fdd3470efde3923" },
@@ -13,7 +13,7 @@
   "diffview.nvim": { "branch": "main", "commit": "4516612fe98ff56ae0415a259ff6361a89419b0a" },
   "dropbar.nvim": { "branch": "master", "commit": "f7ecb0c3600ca1dc467c361e9af40f97289d7aad" },
   "fidget.nvim": { "branch": "main", "commit": "d9ba6b7bfe29b3119a610892af67602641da778e" },
-  "friendly-snippets": { "branch": "main", "commit": "efff286dd74c22f731cdec26a70b46e5b203c619" },
+  "friendly-snippets": { "branch": "main", "commit": "572f5660cf05f8cd8834e096d7b4c921ba18e175" },
   "git-conflict.nvim": { "branch": "main", "commit": "bfd9fe6fba9a161fc199771d85996236a0d0faad" },
   "gitlinker.nvim": { "branch": "master", "commit": "cc59f732f3d043b626c8702cb725c82e54d35c25" },
   "gitsigns.nvim": { "branch": "main", "commit": "1796c7cedfe7e5dd20096c5d7b8b753d8f8d22eb" },

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -3,7 +3,6 @@ local claudeCode = {}
 function claudeCode.config()
 	return {
 		"greggh/claude-code.nvim",
-		commit = "91b38f289c9b1f08007a0443020ed97bb7539ebe",
 		dependencies = {
 			require("plugins.plenary").config(),
 		},

--- a/config/nvim/plugins/claude-code_spec.lua
+++ b/config/nvim/plugins/claude-code_spec.lua
@@ -8,7 +8,6 @@ describe("claudeCode plugin", function()
 				config = function()
 					return {
 						"nvim-lua/plenary.nvim",
-						commit = "857c5ac632080dba10aae49dba902ce3abf91b35",
 					}
 				end,
 			}
@@ -82,14 +81,8 @@ describe("claudeCode plugin", function()
 
 			assert.is_table(config)
 			assert.is_equal("greggh/claude-code.nvim", config[1])
-			assert.is_string(config.commit)
 			assert.is_table(config.dependencies)
 			assert.is_function(config.config)
-		end)
-
-		it("should have the correct commit hash", function()
-			local config = claudeCode.config()
-			assert.is_equal("91b38f289c9b1f08007a0443020ed97bb7539ebe", config.commit)
 		end)
 
 		it("should include plenary dependency", function()

--- a/config/nvim/plugins/cmp-buffer.lua
+++ b/config/nvim/plugins/cmp-buffer.lua
@@ -3,7 +3,6 @@ local cmpBuffer = {}
 function cmpBuffer.config()
 	return {
 		"hrsh7th/cmp-buffer",
-		commit = "b74fab3656eea9de20a9b8116afa3cfc4ec09657",
 	}
 end
 

--- a/config/nvim/plugins/cmp-cmdline.lua
+++ b/config/nvim/plugins/cmp-cmdline.lua
@@ -3,7 +3,6 @@ local cmpCmdline = {}
 function cmpCmdline.config()
 	return {
 		"hrsh7th/cmp-cmdline",
-		commit = "d250c63aa13ead745e3a40f61fdd3470efde3923",
 	}
 end
 

--- a/config/nvim/plugins/cmp-luasnip.lua
+++ b/config/nvim/plugins/cmp-luasnip.lua
@@ -3,7 +3,6 @@ local cmpLuasnip = {}
 function cmpLuasnip.config()
 	return {
 		"saadparwaiz1/cmp_luasnip",
-		commit = "98d9cb5c2c38532bd9bdb481067b20fea8f32e90",
 	}
 end
 

--- a/config/nvim/plugins/cmp-nvim-lsp.lua
+++ b/config/nvim/plugins/cmp-nvim-lsp.lua
@@ -3,7 +3,6 @@ local cmpNvimLsp = {}
 function cmpNvimLsp.config()
 	return {
 		"hrsh7th/cmp-nvim-lsp",
-		commit = "a8912b88ce488f411177fc8aed358b04dc246d7b",
 	}
 end
 

--- a/config/nvim/plugins/cmp-path.lua
+++ b/config/nvim/plugins/cmp-path.lua
@@ -3,7 +3,6 @@ local cmpPath = {}
 function cmpPath.config()
 	return {
 		"hrsh7th/cmp-path",
-		commit = "c6635aae33a50d6010bf1aa756ac2398a2d54c32",
 	}
 end
 

--- a/config/nvim/plugins/comment.lua
+++ b/config/nvim/plugins/comment.lua
@@ -3,7 +3,6 @@ local comment = {}
 function comment.config()
 	return {
 		"numToStr/Comment.nvim",
-		commit = "e30b7f2008e52442154b66f7c519bfd2f1e32acb",
 		config = function()
 			require("Comment").setup({
 				pre_hook = require("ts_context_commentstring.integrations.comment_nvim").create_pre_hook(),

--- a/config/nvim/plugins/copilot-cmp.lua
+++ b/config/nvim/plugins/copilot-cmp.lua
@@ -3,7 +3,6 @@ local copilotCmp = {}
 function copilotCmp.config()
 	return {
 		"zbirenbaum/copilot-cmp",
-		commit = "15fc12af3d0109fa76b60b5cffa1373697e261d1",
 		config = function()
 			require("copilot_cmp").setup()
 		end,

--- a/config/nvim/plugins/copilot.lua
+++ b/config/nvim/plugins/copilot.lua
@@ -3,7 +3,6 @@ local copilot = {}
 function copilot.config()
 	return {
 		"zbirenbaum/copilot.lua",
-		commit = "a5c390f8d8e85b501b22dcb2f30e0cbbd69d5ff0",
 		cmd = "Copilot",
 		event = "InsertEnter",
 		config = function()

--- a/config/nvim/plugins/diffview.lua
+++ b/config/nvim/plugins/diffview.lua
@@ -3,7 +3,6 @@ local diffview = {}
 function diffview.config()
 	return {
 		"sindrets/diffview.nvim",
-		commit = "4516612fe98ff56ae0415a259ff6361a89419b0a",
 	}
 end
 

--- a/config/nvim/plugins/dropbar.lua
+++ b/config/nvim/plugins/dropbar.lua
@@ -3,7 +3,6 @@ local dropbar = {}
 function dropbar.config()
 	return {
 		"Bekaboo/dropbar.nvim",
-		commit = "f7ecb0c3600ca1dc467c361e9af40f97289d7aad",
 		-- optional, but required for fuzzy finder support
 		dependencies = {
 			require("plugins.telescope-fzf-native").config(),

--- a/config/nvim/plugins/fidget.lua
+++ b/config/nvim/plugins/fidget.lua
@@ -3,7 +3,6 @@ local fidget = {}
 function fidget.config()
 	return {
 		"j-hui/fidget.nvim",
-		commit = "d9ba6b7bfe29b3119a610892af67602641da778e",
 		opts = {},
 	}
 end

--- a/config/nvim/plugins/fixcursorhold.lua
+++ b/config/nvim/plugins/fixcursorhold.lua
@@ -3,7 +3,6 @@ local fixCursorHold = {}
 function fixCursorHold.config()
 	return {
 		"antoinemadec/FixCursorHold.nvim",
-		commit = "1900f89dc17c603eec29960f57c00bd9ae696495",
 	}
 end
 

--- a/config/nvim/plugins/friendly-snippets.lua
+++ b/config/nvim/plugins/friendly-snippets.lua
@@ -3,7 +3,6 @@ local friendlySnippets = {}
 function friendlySnippets.config()
 	return {
 		"rafamadriz/friendly-snippets",
-		commit = "efff286dd74c22f731cdec26a70b46e5b203c619",
 	}
 end
 

--- a/config/nvim/plugins/git-conflict.lua
+++ b/config/nvim/plugins/git-conflict.lua
@@ -3,7 +3,6 @@ local gitConflict = {}
 function gitConflict.config()
 	return {
 		"akinsho/git-conflict.nvim",
-		commit = "bfd9fe6fba9a161fc199771d85996236a0d0faad",
 		version = "2.0.0",
 		config = function()
 			require("git-conflict").setup({

--- a/config/nvim/plugins/gitlinker.lua
+++ b/config/nvim/plugins/gitlinker.lua
@@ -3,7 +3,6 @@ local gitlinker = {}
 function gitlinker.config()
 	return {
 		"ruifm/gitlinker.nvim",
-		commit = "cc59f732f3d043b626c8702cb725c82e54d35c25",
 		dependencies = { "nvim-lua/plenary.nvim" },
 		config = function()
 			require("gitlinker").setup({

--- a/config/nvim/plugins/gitsigns.lua
+++ b/config/nvim/plugins/gitsigns.lua
@@ -3,7 +3,6 @@ local gitsign = {}
 function gitsign.config()
 	return {
 		"lewis6991/gitsigns.nvim",
-		commit = "1796c7cedfe7e5dd20096c5d7b8b753d8f8d22eb",
 		opts = {
 			signs = {
 				add = { text = "+" },

--- a/config/nvim/plugins/indent-blankline.lua
+++ b/config/nvim/plugins/indent-blankline.lua
@@ -3,7 +3,6 @@ local indentBlankline = {}
 function indentBlankline.config()
 	return {
 		"lukas-reineke/indent-blankline.nvim",
-		commit = "005b56001b2cb30bfa61b7986bc50657816ba4ba",
 		main = "ibl",
 		opts = {},
 	}

--- a/config/nvim/plugins/lazydev.lua
+++ b/config/nvim/plugins/lazydev.lua
@@ -3,7 +3,6 @@ local lazydev = {}
 function lazydev.config()
 	return {
 		"folke/lazydev.nvim",
-		commit = "2367a6c0a01eb9edb0464731cc0fb61ed9ab9d2c",
 		ft = "lua",
 		opts = {
 			library = {

--- a/config/nvim/plugins/lspkind.lua
+++ b/config/nvim/plugins/lspkind.lua
@@ -3,7 +3,6 @@ local lspkind = {}
 function lspkind.config()
 	return {
 		"onsails/lspkind.nvim",
-		commit = "d79a1c3299ad0ef94e255d045bed9fa26025dab6",
 	}
 end
 

--- a/config/nvim/plugins/lualine.lua
+++ b/config/nvim/plugins/lualine.lua
@@ -3,7 +3,6 @@ local lualine = {}
 function lualine.config()
 	return {
 		"nvim-lualine/lualine.nvim",
-		commit = "15884cee63a8c205334ab13ab1c891cd4d27101a",
 		dependencies = {
 			require("plugins.nvim-web-devicons").config(),
 		},

--- a/config/nvim/plugins/luasnip.lua
+++ b/config/nvim/plugins/luasnip.lua
@@ -3,7 +3,6 @@ local luasnip = {}
 function luasnip.config()
 	return {
 		"L3MON4D3/LuaSnip",
-		commit = "03c8e67eb7293c404845b3982db895d59c0d1538",
 		build = "make install_jsregexp",
 		dependencies = {
 			require("plugins.friendly-snippets").config(),

--- a/config/nvim/plugins/markdown-preview.lua
+++ b/config/nvim/plugins/markdown-preview.lua
@@ -3,7 +3,6 @@ local markdownPreview = {}
 function markdownPreview.config()
 	return {
 		"iamcco/markdown-preview.nvim",
-		commit = "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee",
 		cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
 		build = "cd app && yarn install",
 		init = function()

--- a/config/nvim/plugins/mason-lspconfig.lua
+++ b/config/nvim/plugins/mason-lspconfig.lua
@@ -3,7 +3,6 @@ local masonLspconfig = {}
 function masonLspconfig.config()
 	return {
 		"williamboman/mason-lspconfig.nvim",
-		commit = "1a31f824b9cd5bc6f342fc29e9a53b60d74af245",
 	}
 end
 

--- a/config/nvim/plugins/mason.lua
+++ b/config/nvim/plugins/mason.lua
@@ -3,7 +3,6 @@ local mason = {}
 function mason.config()
 	return {
 		"williamboman/mason.nvim",
-		commit = "fc98833b6da5de5a9c5b1446ac541577059555be",
 		dependencies = {
 			require("plugins.mason-lspconfig").config(),
 			require("plugins.nvim-lspconfig").config(),

--- a/config/nvim/plugins/neogit.lua
+++ b/config/nvim/plugins/neogit.lua
@@ -3,7 +3,6 @@ local neogit = {}
 function neogit.config()
 	return {
 		"NeogitOrg/neogit",
-		commit = "333968f8222fda475d3e4545a9b15fe9912ca26a",
 		dependencies = {
 			require("plugins.plenary").config(),
 			require("plugins.diffview").config(),

--- a/config/nvim/plugins/neotest-rust.lua
+++ b/config/nvim/plugins/neotest-rust.lua
@@ -3,7 +3,6 @@ local neotestRust = {}
 function neotestRust.config()
 	return {
 		"rouge8/neotest-rust",
-		commit = "e1cb22ecf0341fb894ef2ebde344389fe6e6fc8e",
 	}
 end
 

--- a/config/nvim/plugins/neotest-vitest.lua
+++ b/config/nvim/plugins/neotest-vitest.lua
@@ -3,7 +3,6 @@ local neotestVitest = {}
 function neotestVitest.config()
 	return {
 		"marilari88/neotest-vitest",
-		commit = "a6099e1fb55a2c2851da3dd0f4d510af9a234c92",
 	}
 end
 

--- a/config/nvim/plugins/neotest.lua
+++ b/config/nvim/plugins/neotest.lua
@@ -3,7 +3,6 @@ local neotest = {}
 function neotest.config()
 	return {
 		"nvim-neotest/neotest",
-		commit = "6267dcd577aa519c828d2526b05844770d3a2c6a",
 		dependencies = {
 			require("plugins.nvim-nio").config(),
 			require("plugins.plenary").config(),

--- a/config/nvim/plugins/none-ls-extras.lua
+++ b/config/nvim/plugins/none-ls-extras.lua
@@ -3,7 +3,6 @@ local noneLsExtras = {}
 function noneLsExtras.config()
 	return {
 		"nvimtools/none-ls-extras.nvim",
-		commit = "80dfc30b674c45ad892726f656440cc9e69b82e3",
 	}
 end
 

--- a/config/nvim/plugins/none-ls.lua
+++ b/config/nvim/plugins/none-ls.lua
@@ -4,7 +4,6 @@ local noneLs = {}
 function noneLs.config()
 	return {
 		"nvimtools/none-ls.nvim",
-		commit = "a49f5a79cdb76e0dc1a98899c8598f4db014c5e7",
 		dependencies = {
 			require("plugins.none-ls-extras").config(),
 			require("plugins.plenary").config(),

--- a/config/nvim/plugins/nui.lua
+++ b/config/nvim/plugins/nui.lua
@@ -3,7 +3,6 @@ local nui = {}
 function nui.config()
 	return {
 		"MunifTanjim/nui.nvim",
-		commit = "8d5b0b568517935d3c84f257f272ef004d9f5a59",
 	}
 end
 

--- a/config/nvim/plugins/nvim-autopairs.lua
+++ b/config/nvim/plugins/nvim-autopairs.lua
@@ -3,7 +3,6 @@ local nvimAutopairs = {}
 function nvimAutopairs.config()
 	return {
 		"windwp/nvim-autopairs",
-		commit = "84a81a7d1f28b381b32acf1e8fe5ff5bef4f7968",
 		event = "InsertEnter",
 		config = true,
 	}

--- a/config/nvim/plugins/nvim-bqf.lua
+++ b/config/nvim/plugins/nvim-bqf.lua
@@ -3,7 +3,6 @@ local nvimBqf = {}
 function nvimBqf.config()
 	return {
 		"kevinhwang91/nvim-bqf",
-		commit = "e20417d5e589e03eaaaadc4687904528500608be",
 	}
 end
 

--- a/config/nvim/plugins/nvim-cmp.lua
+++ b/config/nvim/plugins/nvim-cmp.lua
@@ -3,7 +3,6 @@ local nvimCmp = {}
 function nvimCmp.config()
 	return {
 		"hrsh7th/nvim-cmp",
-		commit = "b5311ab3ed9c846b585c0c15b7559be131ec4be9",
 		event = { "InsertEnter", "CmdlineEnter" },
 		dependencies = {
 			require("plugins.cmp-nvim-lsp").config(),

--- a/config/nvim/plugins/nvim-colorizer.lua
+++ b/config/nvim/plugins/nvim-colorizer.lua
@@ -3,7 +3,6 @@ local nvimColorizer = {}
 function nvimColorizer.config()
 	return {
 		"norcalli/nvim-colorizer.lua",
-		commit = "a065833f35a3a7cc3ef137ac88b5381da2ba302e",
 		config = function()
 			require("colorizer").setup()
 		end,

--- a/config/nvim/plugins/nvim-context-vt.lua
+++ b/config/nvim/plugins/nvim-context-vt.lua
@@ -3,7 +3,6 @@ local nvimContextVt = {}
 function nvimContextVt.config()
 	return {
 		"andersevenrud/nvim_context_vt",
-		commit = "10e13ec47a9bb341192d893e58cf91c61cde4935",
 		config = function()
 			require("nvim_context_vt").setup()
 		end,

--- a/config/nvim/plugins/nvim-dap-ui.lua
+++ b/config/nvim/plugins/nvim-dap-ui.lua
@@ -3,7 +3,6 @@ local nvimDapUi = {}
 function nvimDapUi.config()
 	return {
 		"rcarriga/nvim-dap-ui",
-		commit = "73a26abf4941aa27da59820fd6b028ebcdbcf932",
 	}
 end
 

--- a/config/nvim/plugins/nvim-dap-virtual-text.lua
+++ b/config/nvim/plugins/nvim-dap-virtual-text.lua
@@ -3,7 +3,6 @@ local nvimDapVirtualText = {}
 function nvimDapVirtualText.config()
 	return {
 		"theHamsta/nvim-dap-virtual-text",
-		commit = "df66808cd78b5a97576bbaeee95ed5ca385a9750",
 	}
 end
 

--- a/config/nvim/plugins/nvim-dap-vscode-js.lua
+++ b/config/nvim/plugins/nvim-dap-vscode-js.lua
@@ -3,7 +3,6 @@ local nvimDapVscodeJs = {}
 function nvimDapVscodeJs.config()
 	return {
 		"mxsdev/nvim-dap-vscode-js",
-		commit = "03bd29672d7fab5e515fc8469b7d07cc5994bbf6",
 	}
 end
 

--- a/config/nvim/plugins/nvim-dap.lua
+++ b/config/nvim/plugins/nvim-dap.lua
@@ -3,7 +3,6 @@ local nvimDap = {}
 function nvimDap.config()
 	return {
 		"mfussenegger/nvim-dap",
-		commit = "8df427aeba0a06c6577dc3ab82de3076964e3b8d",
 		dependencies = {
 			require("plugins.nvim-dap-virtual-text").config(),
 			require("plugins.nvim-dap-ui").config(),

--- a/config/nvim/plugins/nvim-dbee.lua
+++ b/config/nvim/plugins/nvim-dbee.lua
@@ -3,7 +3,6 @@ local nvimDbee = {}
 function nvimDbee.config()
 	return {
 		"kndndrj/nvim-dbee",
-		commit = "ece254aaa322962659321f10329f408775b4beff",
 		dependencies = {
 			"MunifTanjim/nui.nvim",
 		},

--- a/config/nvim/plugins/nvim-lspconfig.lua
+++ b/config/nvim/plugins/nvim-lspconfig.lua
@@ -4,7 +4,6 @@ local nvimLspconfig = {}
 function nvimLspconfig.config()
 	return {
 		"neovim/nvim-lspconfig",
-		commit = "46434074f188e6bfccf9d9153dd8be6b1381498b",
 		dependencies = {
 			require("plugins.fidget").config(),
 			require("plugins.cmp-nvim-lsp").config(),

--- a/config/nvim/plugins/nvim-nio.lua
+++ b/config/nvim/plugins/nvim-nio.lua
@@ -3,7 +3,6 @@ local nvimNio = {}
 function nvimNio.config()
 	return {
 		"nvim-neotest/nvim-nio",
-		commit = "21f5324bfac14e22ba26553caf69ec76ae8a7662",
 	}
 end
 

--- a/config/nvim/plugins/nvim-notify.lua
+++ b/config/nvim/plugins/nvim-notify.lua
@@ -3,7 +3,6 @@ local nvimNotify = {}
 function nvimNotify.config()
 	return {
 		"rcarriga/nvim-notify",
-		commit = "b5825cf9ee881dd8e43309c93374ed5b87b7a896",
 		config = function()
 			local notify = require("notify")
 			notify.setup({

--- a/config/nvim/plugins/nvim-tree.lua
+++ b/config/nvim/plugins/nvim-tree.lua
@@ -3,7 +3,6 @@ local nvimTree = {}
 function nvimTree.config()
 	return {
 		"nvim-tree/nvim-tree.lua",
-		commit = "582ae48c9e43d2bcd55dfcc8e2e7a1f29065d924",
 		dependencies = {
 			require("plugins.nvim-web-devicons").config(),
 		},

--- a/config/nvim/plugins/nvim-treesitter-context.lua
+++ b/config/nvim/plugins/nvim-treesitter-context.lua
@@ -3,7 +3,6 @@ local nvimTreesitterContext = {}
 function nvimTreesitterContext.config()
 	return {
 		"nvim-treesitter/nvim-treesitter-context",
-		commit = "93b29a32d5f4be10e39226c6b796f28d68a8b483",
 		config = function()
 			require("treesitter-context").setup()
 		end,

--- a/config/nvim/plugins/nvim-treesitter.lua
+++ b/config/nvim/plugins/nvim-treesitter.lua
@@ -3,7 +3,6 @@ local nvimTreesitter = {}
 function nvimTreesitter.config()
 	return { -- Highlight, edit, and navigate code
 		"nvim-treesitter/nvim-treesitter",
-		commit = "3b308861a8d7d7bfbe9be51d52e54dcfd9fe3d38",
 		build = ":TSUpdate",
 		main = "nvim-treesitter.configs", -- Sets main module to use for opts
 		opts = {

--- a/config/nvim/plugins/nvim-ts-autotag.lua
+++ b/config/nvim/plugins/nvim-ts-autotag.lua
@@ -3,7 +3,6 @@ local nvimTsAutotag = {}
 function nvimTsAutotag.config()
 	return {
 		"windwp/nvim-ts-autotag",
-		commit = "a1d526af391f6aebb25a8795cbc05351ed3620b5",
 		event = "InsertEnter",
 		config = true,
 	}

--- a/config/nvim/plugins/nvim-ts-context-commentstring.lua
+++ b/config/nvim/plugins/nvim-ts-context-commentstring.lua
@@ -3,7 +3,6 @@ local nvimTsContextCommentstring = {}
 function nvimTsContextCommentstring.config()
 	return {
 		"JoosepAlviste/nvim-ts-context-commentstring",
-		commit = "1b212c2eee76d787bbea6aa5e92a2b534e7b4f8f",
 		config = function()
 			require("ts_context_commentstring").setup({
 				enable_autocmd = false,

--- a/config/nvim/plugins/octo.lua
+++ b/config/nvim/plugins/octo.lua
@@ -3,7 +3,6 @@ local octo = {}
 function octo.config()
 	return {
 		"pwntester/octo.nvim",
-		commit = "974d2247b64535bedbbdbb7bec29dfa4e2395037",
 		dependencies = {
 			require("plugins.plenary").config(),
 			require("plugins.telescope").config(),

--- a/config/nvim/plugins/open-browser.lua
+++ b/config/nvim/plugins/open-browser.lua
@@ -3,7 +3,6 @@ local openBrowser = {}
 function openBrowser.config()
 	return {
 		"tyru/open-browser.vim",
-		commit = "7d4c1d8198e889d513a030b5a83faa07606bac27",
 		config = function()
 			-- Set keymaps for opening URLs
 			vim.keymap.set("n", "gx", "<Plug>(openbrowser-smart-search)", { desc = "Open URL under cursor" })

--- a/config/nvim/plugins/orgmode.lua
+++ b/config/nvim/plugins/orgmode.lua
@@ -3,7 +3,6 @@ local orgmode = {}
 function orgmode.config()
 	return {
 		"nvim-orgmode/orgmode",
-		commit = "15d66ead1285d99f8a21c4ef4874ac62e9320fe6",
 		event = "VeryLazy",
 		ft = { "org" },
 		config = function()

--- a/config/nvim/plugins/package-info.lua
+++ b/config/nvim/plugins/package-info.lua
@@ -3,7 +3,6 @@ local packageInfo = {}
 function packageInfo.config()
 	return {
 		"vuki656/package-info.nvim",
-		commit = "4f1b8287dde221153ec9f2acd46e8237d2d0881e",
 		dependencies = {
 			require("plugins.nui").config(),
 		},

--- a/config/nvim/plugins/pathtool.lua
+++ b/config/nvim/plugins/pathtool.lua
@@ -5,7 +5,6 @@ function pathtool.config()
 		"mikinovation/pathtool.nvim",
 		-- renovate: datasource=github-releases depName=mikinovation/pathtool.nvim
 		-- commit=a4a97ffee7b105451c5925beb444847cdc468b
-		commit = "dfed489d1e6a628ca73ceafbdfa30e5d55ca481b",
 		config = function()
 			require("pathtool").setup()
 

--- a/config/nvim/plugins/plenary.lua
+++ b/config/nvim/plugins/plenary.lua
@@ -3,7 +3,6 @@ local plenary = {}
 function plenary.config()
 	return {
 		"nvim-lua/plenary.nvim",
-		commit = "857c5ac632080dba10aae49dba902ce3abf91b35",
 	}
 end
 

--- a/config/nvim/plugins/quick-scope.lua
+++ b/config/nvim/plugins/quick-scope.lua
@@ -3,7 +3,6 @@ local quickScope = {}
 function quickScope.config()
 	return {
 		"unblevable/quick-scope",
-		commit = "f2b6043e04d9ef05205c8953e389304a4c1946f2",
 		config = function()
 			-- Set highlight colors that match with tokyonight theme
 			vim.cmd([[

--- a/config/nvim/plugins/rest.lua
+++ b/config/nvim/plugins/rest.lua
@@ -4,7 +4,6 @@ function rest.config()
 	return {
 		"rest-nvim/rest.nvim",
 		-- renovate: datasource=git-refs depName=https://github.com/rest-nvim/rest.nvim
-		commit = "2ded89dbda1fd3c1430685ffadf2df8beb28336d",
 		dependencies = {
 			"nvim-treesitter/nvim-treesitter",
 			opts = function(_, opts)

--- a/config/nvim/plugins/sqlite.lua
+++ b/config/nvim/plugins/sqlite.lua
@@ -3,7 +3,6 @@ local sqlite = {}
 function sqlite.config()
 	return {
 		"kkharji/sqlite.lua",
-		commit = "50092d60feb242602d7578398c6eb53b4a8ffe7b",
 	}
 end
 

--- a/config/nvim/plugins/telescope-file-browser.lua
+++ b/config/nvim/plugins/telescope-file-browser.lua
@@ -3,7 +3,6 @@ local telescopeFileBrowser = {}
 function telescopeFileBrowser.config()
 	return {
 		"nvim-telescope/telescope-file-browser.nvim",
-		commit = "626998e5c1b71c130d8bc6cf7abb6709b98287bb",
 	}
 end
 

--- a/config/nvim/plugins/telescope-frecency.lua
+++ b/config/nvim/plugins/telescope-frecency.lua
@@ -3,7 +3,6 @@ local telescopeFrecency = {}
 function telescopeFrecency.config()
 	return {
 		"nvim-telescope/telescope-frecency.nvim",
-		commit = "4d2f5854d3a161b355c4949059e6cd1087fd1d4a",
 		dependencies = {
 			require("plugins.sqlite").config(),
 		},

--- a/config/nvim/plugins/telescope-fzf-native.lua
+++ b/config/nvim/plugins/telescope-fzf-native.lua
@@ -3,7 +3,6 @@ local telescopeFzfNative = {}
 function telescopeFzfNative.config()
 	return {
 		"nvim-telescope/telescope-fzf-native.nvim",
-		commit = "1f08ed60cafc8f6168b72b80be2b2ea149813e55",
 		build = "make",
 		cond = function()
 			return vim.fn.executable("make") == 1

--- a/config/nvim/plugins/telescope-media-files.lua
+++ b/config/nvim/plugins/telescope-media-files.lua
@@ -3,7 +3,6 @@ local telescopeMediaFiles = {}
 function telescopeMediaFiles.config()
 	return {
 		"nvim-telescope/telescope-media-files.nvim",
-		commit = "0826c7a730bc4d36068f7c85cf4c5b3fd9fb570a",
 	}
 end
 

--- a/config/nvim/plugins/telescope-project.lua
+++ b/config/nvim/plugins/telescope-project.lua
@@ -3,7 +3,6 @@ local telescopeProject = {}
 function telescopeProject.config()
 	return {
 		"nvim-telescope/telescope-project.nvim",
-		commit = "ce2c9fe209a68c7a924acde42d94ed8a2b2a52c5",
 	}
 end
 

--- a/config/nvim/plugins/telescope-repo.lua
+++ b/config/nvim/plugins/telescope-repo.lua
@@ -3,7 +3,6 @@ local telescopeRepo = {}
 function telescopeRepo.config()
 	return {
 		"cljoly/telescope-repo.nvim",
-		commit = "a5395a4bf0fd742cc46b4e8c50e657062f548ba9",
 	}
 end
 

--- a/config/nvim/plugins/telescope-ui-select.lua
+++ b/config/nvim/plugins/telescope-ui-select.lua
@@ -3,7 +3,6 @@ local telescopeUiSelect = {}
 function telescopeUiSelect.config()
 	return {
 		"nvim-telescope/telescope-ui-select.nvim",
-		commit = "6e51d7da30bd139a6950adf2a47fda6df9fa06d2",
 	}
 end
 

--- a/config/nvim/plugins/telescope.lua
+++ b/config/nvim/plugins/telescope.lua
@@ -3,7 +3,6 @@ local telescope = {}
 function telescope.config()
 	return { -- Fuzzy Finder (files, lsp, etc)
 		"nvim-telescope/telescope.nvim",
-		commit = "b4da76be54691e854d3e0e02c36b0245f945c2c7",
 		event = "VimEnter",
 		dependencies = {
 			require("plugins.plenary").config(),

--- a/config/nvim/plugins/todo-comments.lua
+++ b/config/nvim/plugins/todo-comments.lua
@@ -3,7 +3,6 @@ local todoComments = {}
 function todoComments.config()
 	return { -- You can easily change to a different colorscheme.
 		"folke/todo-comments.nvim",
-		commit = "304a8d204ee787d2544d8bc23cd38d2f929e7cc5",
 		event = "VimEnter",
 		dependencies = {
 			require("plugins.plenary").config(),

--- a/config/nvim/plugins/toggleterm.lua
+++ b/config/nvim/plugins/toggleterm.lua
@@ -3,7 +3,6 @@ local toggleterm = {}
 function toggleterm.config()
 	return {
 		"akinsho/toggleterm.nvim",
-		commit = "50ea089fc548917cc3cc16b46a8211833b9e3c7c",
 		version = "*",
 		config = function()
 			require("toggleterm").setup({

--- a/config/nvim/plugins/tokyonight.lua
+++ b/config/nvim/plugins/tokyonight.lua
@@ -3,7 +3,6 @@ local tokyonight = {}
 function tokyonight.config()
 	return { -- You can easily change to a different colorscheme.
 		"folke/tokyonight.nvim",
-		commit = "057ef5d260c1931f1dffd0f052c685dcd14100a3",
 		priority = 1000, -- Make sure to load this before all the other start plugins.
 		init = function()
 			vim.cmd.colorscheme("tokyonight-night")

--- a/config/nvim/plugins/tsc.lua
+++ b/config/nvim/plugins/tsc.lua
@@ -3,7 +3,6 @@ local tsc = {}
 function tsc.config()
 	return {
 		"dmmulroy/tsc.nvim",
-		commit = "5bd25bb5c399b6dc5c00392ade6ac6198534b53a",
 		config = function()
 			require("tsc").setup({})
 		end,

--- a/config/nvim/plugins/vim-argwrap.lua
+++ b/config/nvim/plugins/vim-argwrap.lua
@@ -3,7 +3,6 @@ local vimArgwrap = {}
 function vimArgwrap.config()
 	return {
 		"FooSoft/vim-argwrap",
-		commit = "f3e26a5ad249d09467804b92e760d08b1cc457a1",
 		config = function()
 			-- Vim-Argwrap keymap
 			vim.keymap.set("n", "<leader>aw", ":ArgWrap<CR>", { desc = "Argwrap" })

--- a/config/nvim/plugins/vim-bundler.lua
+++ b/config/nvim/plugins/vim-bundler.lua
@@ -3,7 +3,6 @@ local vimBundler = {}
 function vimBundler.config()
 	return {
 		"tpope/vim-bundler",
-		commit = "c261509e78fc8dc55ad1fcf3cd7cdde49f35435c",
 	}
 end
 

--- a/config/nvim/plugins/vim-fugitive.lua
+++ b/config/nvim/plugins/vim-fugitive.lua
@@ -3,7 +3,6 @@ local vimFugitive = {}
 function vimFugitive.config()
 	return {
 		"tpope/vim-fugitive",
-		commit = "4a745ea72fa93bb15dd077109afbb3d1809383f2",
 		config = function()
 			-- Basic Git operations
 			vim.keymap.set("n", "<leader>gs", ":Git<CR>", { desc = "Git [S]tatus" })

--- a/config/nvim/plugins/vim-illuminate.lua
+++ b/config/nvim/plugins/vim-illuminate.lua
@@ -3,7 +3,6 @@ local vimIlluminate = {}
 function vimIlluminate.config()
 	return {
 		"RRethy/vim-illuminate",
-		commit = "fbc16dee336d8cc0d3d2382ea4a53f4a29725abf",
 		config = function()
 			require("illuminate").configure()
 		end,

--- a/config/nvim/plugins/vim-matchup.lua
+++ b/config/nvim/plugins/vim-matchup.lua
@@ -3,7 +3,6 @@ local vimMatchup = {}
 function vimMatchup.config()
 	return {
 		"andymass/vim-matchup",
-		commit = "ea2ff43e09e68b63fc6d9268fc5d82d82d433cb3",
 	}
 end
 

--- a/config/nvim/plugins/vim-rails.lua
+++ b/config/nvim/plugins/vim-rails.lua
@@ -4,7 +4,6 @@ local vimRails = {}
 function vimRails.config()
 	return {
 		"tpope/vim-rails",
-		commit = "d3954dfe3946c9330dc91b4fbf79ccacb2c626c0",
 	}
 end
 

--- a/config/nvim/plugins/vim-sleuth.lua
+++ b/config/nvim/plugins/vim-sleuth.lua
@@ -3,7 +3,6 @@ local vimSleuth = {}
 function vimSleuth.config()
 	return {
 		"tpope/vim-sleuth",
-		commit = "be69bff86754b1aa5adcbb527d7fcd1635a84080",
 	}
 end
 

--- a/config/nvim/plugins/vscode-js-debug.lua
+++ b/config/nvim/plugins/vscode-js-debug.lua
@@ -3,7 +3,6 @@ local vscodeJsDebug = {}
 function vscodeJsDebug.config()
 	return {
 		"microsoft/vscode-js-debug",
-		commit = "3ed213faba62916c4d73233bd837a57179b40b2a",
 		build = "npm isntall --legacy-peer-deps && npm run compile",
 	}
 end

--- a/config/nvim/plugins/which-key.lua
+++ b/config/nvim/plugins/which-key.lua
@@ -3,7 +3,6 @@ local whichKey = {}
 function whichKey.config()
 	return { -- Useful plugin to show you pending keybinds.
 		"folke/which-key.nvim",
-		commit = "370ec46f710e058c9c1646273e6b225acf47cbed",
 		event = "VimEnter", -- Sets the loading event to 'VimEnter'
 		opts = {
 			icons = {

--- a/config/nvim/plugins/yanky.lua
+++ b/config/nvim/plugins/yanky.lua
@@ -3,7 +3,6 @@ local yanky = {}
 function yanky.config()
 	return {
 		"gbprod/yanky.nvim",
-		commit = "04775cc6e10ef038c397c407bc17f00a2f52b378",
 		opts = {},
 		config = function()
 			require("yanky").setup({


### PR DESCRIPTION
### 🔗 Linked issue

<\!-- No specific issue for this maintenance task -->

### 📚 Description

This PR removes all hard-coded commit hash specifications from Neovim plugin configurations to allow plugins to use their latest versions and simplify maintenance.

**Changes made:**
- Removed `commit = "..."` lines from all plugin configuration files in `config/nvim/plugins/`
- Updated `lazy-lock.json` to reflect the latest commit hashes after removing the pinned versions
- Affects 83 plugin configuration files

**Benefits:**
- Plugins will automatically use their latest stable versions
- Reduces maintenance overhead of manually updating commit hashes
- Allows Lazy.nvim's built-in update mechanisms to work more effectively
- Simplifies plugin configuration files

This is a maintenance improvement that doesn't affect functionality but makes the configuration more maintainable going forward.