### PR TITLE
feat: add Nix flake configuration

### DIFF
--- a/config/nix/flake.nix
+++ b/config/nix/flake.nix
@@ -1,0 +1,23 @@
+{
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [ pkgs.hello ];
+      };
+      packages.${system}.default = pkgs.hello;
+    };
+}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds a Nix flake configuration file to enable reproducible development environments using Nix.

The flake includes:
- Experimental features enabled for nix-command and flakes
- nixpkgs-unstable as the input source
- A development shell with hello package as an example
- Default package configuration for x86_64-linux systems

This provides a foundation for managing development dependencies and ensuring consistent environments across different machines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a Nix flake to standardize and reproduce the development environment.
  * Enabled required Nix experimental features for consistent tooling.
  * Added a default development shell with preinstalled tools for faster onboarding.
  * Exposed a default package output for easy access and testing.
  * Pinned dependencies to an unstable channel to provide up-to-date tooling during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->