### PR TITLE
feat: add orgmode tag functionality and nvim-cmp integration

### DIFF
--- a/config/nvim/plugins/nvim-cmp.lua
+++ b/config/nvim/plugins/nvim-cmp.lua
@@ -73,6 +73,7 @@ function nvimCmp.config()
 				}),
 
 				sources = {
+					{ name = "orgmode", group_index = 2 },
 					{ name = "copilot", group_index = 2 },
 					{ name = "nvim_lsp", group_index = 2 },
 					{ name = "luasnip", group_index = 2 },

--- a/config/nvim/plugins/orgmode.lua
+++ b/config/nvim/plugins/orgmode.lua
@@ -8,6 +8,9 @@ function orgmode.config()
 			require("orgmode").setup({
 				org_agenda_files = { "~/projects/org/**/*" },
 				org_default_notes_file = "~/projects/org/refile.org",
+				org_tags_column = 20,
+				org_use_tag_inheritance = true,
+				org_tags_exclude_from_inheritance = {},
 			})
 		end,
 		mappings = {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds orgmode tag functionality configuration and integrates orgmode with nvim-cmp for better autocompletion support.

**Changes:**
- Added orgmode tag settings (`org_tags_column`, `org_use_tag_inheritance`, `org_tags_exclude_from_inheritance`)
- Integrated orgmode as a completion source in nvim-cmp
- Set orgmode completion source with group_index 2 for proper priority

**Why this change?**
- Enables tag inheritance in orgmode files for better organization
- Provides autocompletion for orgmode syntax through nvim-cmp
- Improves the overall orgmode editing experience in Neovim