### PR TITLE
refactor: send file references instead of code content to Claude Code

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -1,7 +1,7 @@
 {
   "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
   "FixCursorHold.nvim": { "branch": "master", "commit": "1900f89dc17c603eec29960f57c00bd9ae696495" },
-  "LuaSnip": { "branch": "master", "commit": "de10d8414235b0a8cabfeba60d07c24304e71f5c" },
+  "LuaSnip": { "branch": "master", "commit": "73813308abc2eaeff2bc0d3f2f79270c491be9d7" },
   "claude-code.nvim": { "branch": "main", "commit": "91b38f289c9b1f08007a0443020ed97bb7539ebe" },
   "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
   "cmp-cmdline": { "branch": "main", "commit": "d250c63aa13ead745e3a40f61fdd3470efde3923" },
@@ -56,7 +56,6 @@
   "package-info.nvim": { "branch": "master", "commit": "4f1b8287dde221153ec9f2acd46e8237d2d0881e" },
   "pathtool.nvim": { "branch": "main", "commit": "dfed489d1e6a628ca73ceafbdfa30e5d55ca481b" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
-  "pomo.nvim": { "branch": "main", "commit": "7e06e5221d8d1e596a0ab29dd4d7fcee5f3cd05a" },
   "quick-scope": { "branch": "master", "commit": "f2b6043e04d9ef05205c8953e389304a4c1946f2" },
   "rest.nvim": { "branch": "main", "commit": "2ded89dbda1fd3c1430685ffadf2df8beb28336d" },
   "sqlite.lua": { "branch": "master", "commit": "50092d60feb242602d7578398c6eb53b4a8ffe7b" },

--- a/config/nvim/plugins/claude-code.lua
+++ b/config/nvim/plugins/claude-code.lua
@@ -327,13 +327,13 @@ function claudeCode.config()
 			end
 
 			vim.api.nvim_create_user_command("ClaudeCodeSendCurrentLine", function()
-				local lines, file_info = get_current_line_content()
-				claude_client.send_lines_to_claude(lines, file_info)
+				local _, file_info = get_current_line_content()
+				claude_client.send_lines_to_claude(file_info)
 			end, { desc = "Send current line to Claude Code" })
 
 			vim.api.nvim_create_user_command("ClaudeCodeSendSelection", function()
-				local lines, file_info = get_visual_selection_content()
-				claude_client.send_lines_to_claude(lines, file_info)
+				local _, file_info = get_visual_selection_content()
+				claude_client.send_lines_to_claude(file_info)
 			end, { range = true, desc = "Send visual selection to Claude Code" })
 
 			vim.keymap.set(

--- a/config/nvim/plugins/claude_code/claude_client.lua
+++ b/config/nvim/plugins/claude_code/claude_client.lua
@@ -35,26 +35,16 @@ function claude_client.send_file_paths_to_claude(file_paths)
 	claude_client.send_to_claude(file_paths_text)
 end
 
-function claude_client.send_lines_to_claude(lines, file_info)
-	if not lines or #lines == 0 then
-		vim.notify("No lines to send", vim.log.levels.WARN)
+function claude_client.send_lines_to_claude(file_info)
+	if not file_info or not file_info.path then
+		vim.notify("No file info available", vim.log.levels.WARN)
 		return
 	end
 
-	local content_parts = {}
-	if file_info and file_info.path then
-		local line_info = file_info.line_start == file_info.line_end and file_info.line_start
-			or file_info.line_start .. "-" .. file_info.line_end
-		table.insert(content_parts, file_info.path .. ":" .. line_info)
-		table.insert(content_parts, "")
-	end
+	local line_info = file_info.line_start == file_info.line_end and file_info.line_start
+		or file_info.line_start .. "-" .. file_info.line_end
+	local content = file_info.path .. ":" .. line_info
 
-	-- Add the actual line content
-	for _, line in ipairs(lines) do
-		table.insert(content_parts, line)
-	end
-
-	local content = table.concat(content_parts, "\n")
 	claude_client.send_to_claude(content)
 end
 

--- a/config/nvim/plugins/claude_code/claude_client_spec.lua
+++ b/config/nvim/plugins/claude_code/claude_client_spec.lua
@@ -108,55 +108,49 @@ describe("claude_client", function()
 	end)
 
 	describe("send_lines_to_claude", function()
-		it("should send lines with file info", function()
+		it("should send only file path and line range", function()
 			local send_to_claude_spy = spy.on(claude_client, "send_to_claude")
 
-			local lines = { "line1", "line2" }
 			local file_info = {
 				path = "test.lua",
 				line_start = 1,
 				line_end = 2,
 			}
 
-			claude_client.send_lines_to_claude(lines, file_info)
+			claude_client.send_lines_to_claude(file_info)
 
-			assert.spy(send_to_claude_spy).was_called_with("test.lua:1-2\n\nline1\nline2")
+			assert.spy(send_to_claude_spy).was_called_with("test.lua:1-2")
 		end)
 
-		it("should handle single line", function()
+		it("should handle single line without range", function()
 			local send_to_claude_spy = spy.on(claude_client, "send_to_claude")
 
-			local lines = { "single line" }
 			local file_info = {
 				path = "test.lua",
 				line_start = 5,
 				line_end = 5,
 			}
 
-			claude_client.send_lines_to_claude(lines, file_info)
+			claude_client.send_lines_to_claude(file_info)
 
-			assert.spy(send_to_claude_spy).was_called_with("test.lua:5\n\nsingle line")
+			assert.spy(send_to_claude_spy).was_called_with("test.lua:5")
 		end)
 
-		it("should send lines without file info", function()
-			local send_to_claude_spy = spy.on(claude_client, "send_to_claude")
+		it("should notify when file info is not provided", function()
+			claude_client.send_lines_to_claude(nil)
 
-			local lines = { "line1", "line2" }
-			claude_client.send_lines_to_claude(lines, nil)
-
-			assert.spy(send_to_claude_spy).was_called_with("line1\nline2")
+			assert.spy(_G.vim.notify).was_called_with("No file info available", 1)
 		end)
 
-		it("should notify when no lines provided", function()
-			claude_client.send_lines_to_claude({}, nil)
+		it("should notify when file path is missing", function()
+			local file_info = {
+				line_start = 1,
+				line_end = 2,
+			}
 
-			assert.spy(_G.vim.notify).was_called_with("No lines to send", 1)
-		end)
+			claude_client.send_lines_to_claude(file_info)
 
-		it("should notify when lines is nil", function()
-			claude_client.send_lines_to_claude(nil, nil)
-
-			assert.spy(_G.vim.notify).was_called_with("No lines to send", 1)
+			assert.spy(_G.vim.notify).was_called_with("No file info available", 1)
 		end)
 	end)
 end)


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR refactors the Claude Code integration to send only file path references with line numbers (e.g., `file.lua:1-5`) instead of copying and pasting the actual code content.

**Changes:**
- Modified `send_lines_to_claude()` to accept only `file_info` instead of both `lines` and `file_info`
- Removed code content extraction and concatenation logic
- Updated error handling to check for file info availability
- Updated all corresponding tests to reflect the new behavior
- Simplified the function signature in command definitions

**Benefits:**
- Reduces redundant data transmission
- Relies on Claude Code's native file reading capability
- Cleaner and more maintainable code
- Better separation of concerns

**Testing:**
- All existing tests have been updated and pass with the new implementation
- Error cases are properly handled with appropriate notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LuaSnip dependency to latest version.
  * Removed pomo.nvim plugin from dependencies.

* **Bug Fixes**
  * Modified Claude Code commands to optimize data transmission to Claude by sending file location and line range information only, reducing payload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->