### PR TITLE
feat: add Rust development environment configuration

### DIFF
--- a/config/nix/configs/rust.nix
+++ b/config/nix/configs/rust.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    # Rust toolchain (includes rustc, cargo, rust-analyzer, rustfmt, clippy)
+    rustup
+
+    # Build dependencies
+    gcc
+    gnumake
+    pkg-config
+    openssl
+  ];
+
+  # Environment variables for Rust
+  home.sessionVariables = {
+    # Cargo installation directory
+    CARGO_HOME = "${config.home.homeDirectory}/.cargo";
+    RUSTUP_HOME = "${config.home.homeDirectory}/.rustup";
+  };
+
+  # Add cargo bin to PATH
+  home.sessionPath = [
+    "${config.home.homeDirectory}/.cargo/bin"
+  ];
+
+  # Create cargo config
+  home.file.".cargo/config.toml".text = ''
+    [build]
+    jobs = 4
+
+    [term]
+    color = "auto"
+  '';
+}

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -32,6 +32,7 @@
     ./configs/zsh.nix
     ./configs/nodejs.nix
     ./configs/ruby.nix
+    ./configs/rust.nix
     ./configs/database.nix
   ];
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR adds Rust development environment configuration to the Nix setup.

Changes include:
- Created `config/nix/configs/rust.nix` with Rust toolchain setup using rustup
- Added essential build dependencies (gcc, gnumake, pkg-config, openssl)
- Configured environment variables for Cargo and Rustup
- Set up cargo configuration with build parallelism and colored output
- Imported the Rust configuration in `home.nix`

This setup provides a complete Rust development environment with proper tooling and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Rust development environment with automatic toolchain installation, necessary build dependencies, environment variables, and optimized build settings for seamless developer setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->