### PR TITLE
feat: Add zoxide for enhanced directory navigation

### DIFF
--- a/config/nix/configs/zsh.nix
+++ b/config/nix/configs/zsh.nix
@@ -36,6 +36,9 @@
       fi
       eval "$(fnm env --use-on-cd --shell zsh)"
 
+      # zoxide configuration
+      eval "$(zoxide init zsh --cmd cd)"
+
       # Load WSL specific configurations if on WSL
       [[ -f ~/dotfiles/config/zsh/plugins/wsl.zsh ]] && source ~/dotfiles/config/zsh/plugins/wsl.zsh
 

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -22,6 +22,7 @@
     sheldon  # Zsh plugin manager
     fnm      # Fast Node Manager
     uv       # Python package manager
+    zoxide   # Smart cd replacement
 
     # Add more packages here as needed
   ];


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds zoxide, a smarter cd command that learns your most used directories and allows you to jump to them with minimal keystrokes.

**Changes:**
- Added `zoxide` package to Nix home configuration
- Configured zoxide initialization in zsh with `--cmd cd` flag to replace the standard cd command
- This enables intelligent directory navigation based on frecency (frequency + recency)

**Benefits:**
- Faster navigation to frequently accessed directories
- Reduced typing with fuzzy matching
- Learns from usage patterns over time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated zoxide smart directory navigation tool into the shell environment. The tool now automatically initializes during shell startup, enabling users to quickly jump between frequently visited directories for improved terminal navigation efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->