### PR TITLE
feat: add zsh abbreviations configuration and change locale to English

### DIFF
--- a/config/nix/configs/zsh.nix
+++ b/config/nix/configs/zsh.nix
@@ -42,6 +42,9 @@
       # Load WSL specific configurations if on WSL
       [[ -f ~/dotfiles/config/zsh/plugins/wsl.zsh ]] && source ~/dotfiles/config/zsh/plugins/wsl.zsh
 
+      # Load zsh abbreviations
+      [[ -f ~/dotfiles/config/zsh/plugins/abbr.zsh ]] && source ~/dotfiles/config/zsh/plugins/abbr.zsh
+
       # Load Powerlevel10k configuration
       [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 

--- a/config/zsh/plugins/abbr.zsh
+++ b/config/zsh/plugins/abbr.zsh
@@ -1,0 +1,30 @@
+# zsh-abbr configuration
+# https://github.com/olets/zsh-abbr
+
+# Git abbreviations
+abbr -S g="git"
+abbr -S gs="git status"
+abbr -S ga="git add"
+abbr -S gaa="git add ."
+abbr -S gcm="git commit -m"
+abbr -S gco="git checkout"
+abbr -S gcb="git checkout -b"
+abbr -S gp="git push"
+abbr -S gpl="git pull"
+abbr -S gl="git log"
+abbr -S gb="git branch"
+abbr -S gm="git merge"
+abbr -S gr="git rebase"
+
+# Docker abbreviations
+abbr -S d="docker"
+abbr -S dc="docker compose"
+abbr -S dcu="docker compose up"
+abbr -S dcd="docker compose down"
+abbr -S dcb="docker compose build"
+abbr -S dps="docker ps"
+abbr -S di="docker images"
+
+# Common commands
+abbr -S v="nvim"
+abbr -S vim="nvim"

--- a/config/zsh/plugins/wsl.zsh
+++ b/config/zsh/plugins/wsl.zsh
@@ -5,8 +5,8 @@ if grep -q microsoft /proc/version; then
   alias pbcopy="clip.exe"
   alias pbpaste="powershell.exe -command 'Get-Clipboard' | tr -d '\r'"
 
-  # Japanese locale settings for WSL
-  export LANG=ja_JP.UTF-8
-  export LC_ALL=ja_JP.UTF-8
-  export LANGUAGE=ja_JP:ja
+  # Locale settings for WSL
+  export LANG=en_US.UTF-8
+  export LC_ALL=en_US.UTF-8
+  export LANGUAGE=en_US:en
 fi


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds zsh abbreviations configuration using zsh-abbr and changes the WSL locale from Japanese to English.

**Changes made:**
- Added new abbreviations configuration file (`config/zsh/plugins/abbr.zsh`) with:
  - Git abbreviations (g, gs, ga, gaa, gcm, gco, gcb, gp, gpl, gl, gb, gm, gr)
  - Docker abbreviations (d, dc, dcu, dcd, dcb, dps, di)
  - Common command abbreviations (v, vim -> nvim)
- Integrated abbr.zsh loading into zsh.nix configuration
- Changed WSL locale settings from ja_JP.UTF-8 to en_US.UTF-8 for better compatibility

The abbreviations improve command-line productivity by providing quick shortcuts for frequently used commands while maintaining readability with the `-S` flag (show expanded command before execution).