### PR TITLE
feat: add activation script to set zsh as default shell

### DIFF
--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -82,6 +82,28 @@
 
   xdg.configFile."nix/nix.conf".force = true;
 
+  # Set zsh as default shell using activation script
+  # This is necessary for standalone home-manager (non-NixOS)
+  home.activation.make-zsh-default-shell = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    PATH="/usr/bin:/bin:$PATH"
+    ZSH_PATH="${config.home.homeDirectory}/.nix-profile/bin/zsh"
+
+    if [[ $(getent passwd ${config.home.username}) != *"$ZSH_PATH" ]]; then
+      echo "Setting zsh as default shell (using chsh). Password might be necessary."
+
+      if ! grep -q "$ZSH_PATH" /etc/shells; then
+        echo "Adding zsh to /etc/shells"
+        $DRY_RUN_CMD echo "$ZSH_PATH" | sudo tee -a /etc/shells
+      fi
+
+      echo "Running chsh to make zsh the default shell"
+      $DRY_RUN_CMD chsh -s "$ZSH_PATH" ${config.home.username}
+      echo "Zsh is now set as default shell!"
+    else
+      echo "Zsh is already the default shell"
+    fi
+  '';
+
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds a home-manager activation script that automatically sets zsh as the default shell for standalone home-manager installations (non-NixOS systems).

The activation script:
- Checks if zsh is already set as the default shell
- Adds the Nix-managed zsh to `/etc/shells` if not already present
- Uses `chsh` to change the default shell to zsh
- Provides informative messages during the process
- Only runs when necessary (skips if zsh is already the default)

This is necessary for standalone home-manager because it doesn't have the system-level integration that NixOS has for managing default shells.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated default shell configuration that sets zsh as the default shell during system initialization. The process includes dry-run support for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->