### PR TITLE
feat: add neovim configuration to nix setup

### DIFF
--- a/config/nix/configs/neovim.nix
+++ b/config/nix/configs/neovim.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, ... }:
+
+{
+  programs.neovim = {
+    enable = true;
+    defaultEditor = true;
+    viAlias = true;
+    vimAlias = true;
+    vimdiffAlias = true;
+
+    # Install additional packages that neovim plugins might need
+    extraPackages = with pkgs; [
+      # Language servers
+      lua-language-server
+
+      # Formatters and linters
+      stylua  # Lua formatter
+    ];
+  };
+
+  # Session variables for neovim
+  home.sessionVariables = {
+    EDITOR = "nvim";
+    VISUAL = "nvim";
+  };
+}

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -30,6 +30,7 @@
   imports = [
     ./configs/git.nix
     ./configs/zsh.nix
+    ./configs/neovim.nix
     ./configs/nodejs.nix
     ./configs/ruby.nix
     ./configs/rust.nix
@@ -53,7 +54,7 @@
   #  /etc/profiles/per-user/mikinovation/etc/profile.d/hm-session-vars.sh
   #
   home.sessionVariables = {
-    # EDITOR = "emacs";
+    # Note: EDITOR and VISUAL are set in neovim.nix
   };
 
   # Manage dotfiles using home.file


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds Neovim configuration to the Nix home-manager setup.

**Changes:**
- Created new `config/nix/configs/neovim.nix` configuration file
- Enabled Neovim as the default editor with vi/vim aliases
- Added essential Neovim packages:
  - lua-language-server for Lua LSP support
  - stylua for Lua code formatting
- Set EDITOR and VISUAL environment variables to nvim
- Updated `home.nix` to import the new Neovim configuration

**Benefits:**
- Consistent Neovim setup across all machines managed by Nix
- Declarative editor configuration
- Built-in language server and formatter support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Neovim is now configured as the default editor with Lua language server and stylua support.
  * Environment variables (EDITOR and VISUAL) are set to Neovim.
  * Editor configuration has been organized into a dedicated module for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->