### PR TITLE
feat: add yanked text search functionality to Telescope

### DIFF
--- a/config/nvim/plugins/telescope.lua
+++ b/config/nvim/plugins/telescope.lua
@@ -61,7 +61,7 @@ function telescope.config()
 							["<C-j>"] = require("telescope.actions").move_selection_next,
 							["<C-k>"] = require("telescope.actions").move_selection_previous,
 							["<C-q>"] = require("telescope.actions").send_to_qflist
-							    + require("telescope.actions").open_qflist,
+								+ require("telescope.actions").open_qflist,
 							["<C-s>"] = require("telescope.actions").toggle_selection,
 							["<C-u>"] = false,
 							["<C-d>"] = false,
@@ -203,8 +203,7 @@ function telescope.config()
 						map("i", "<CR>", function(prompt_bufnr)
 							local confirmation = vim.fn.input("Execute? (y/n): ")
 							if confirmation:lower() == "y" then
-								vim.cmd("%s/" ..
-								search_term .. "/" .. replace_term .. "/g")
+								vim.cmd("%s/" .. search_term .. "/" .. replace_term .. "/g")
 								require("telescope.actions").close(prompt_bufnr)
 							end
 						end)
@@ -238,8 +237,7 @@ function telescope.config()
 			vim.keymap.set("n", "<leader>fw", builtin.grep_string, { desc = "[F]ind Current [W]ord" })
 			vim.keymap.set("n", "<leader>fg", builtin.live_grep, { desc = "[F]ind by [G]rep" })
 			vim.keymap.set("n", "<leader>fr", builtin.resume, { desc = "[F]ind [R]esume" })
-			vim.keymap.set("n", "<leader>f.", builtin.oldfiles,
-				{ desc = '[F]ind Recent Files ("." for repeat)' })
+			vim.keymap.set("n", "<leader>f.", builtin.oldfiles, { desc = '[F]ind Recent Files ("." for repeat)' })
 			vim.keymap.set("n", "<leader>fb", builtin.buffers, { desc = "[F]ind [B]uffers" })
 
 			-- Additional Telescope keymappings
@@ -294,8 +292,7 @@ function telescope.config()
 
 			vim.keymap.set("n", "<leader>fc", builtin.commands, { desc = "[F]ind [C]ommands" })
 			vim.keymap.set("n", "<leader>fm", ":Telescope media_files<CR>", { desc = "[F]ind [M]edia Files" })
-			vim.keymap.set("n", "<leader>sf", ":Telescope frecency<CR>",
-				{ desc = "[S]earch [F]requent Files" })
+			vim.keymap.set("n", "<leader>sf", ":Telescope frecency<CR>", { desc = "[S]earch [F]requent Files" })
 
 			-- Git integration
 			vim.keymap.set("n", "<leader>gs", builtin.git_status, { desc = "[G]it [S]tatus" })


### PR DESCRIPTION
### 🔗 Linked issue

N/A - Enhancement to improve Telescope workflow

### 📚 Description

This PR adds new functionality to search for yanked text using Telescope, improving the workflow when you want to search for text you've just copied.

**Changes:**
- Added `grep_yanked_text()` function that searches for yanked text across the codebase using grep
- Added `find_files_yanked()` function that uses yanked text as initial search term in file finder
- New keybindings:
  - `<leader>fyg`: Find yanked text using grep search
  - `<leader>fyf`: Find files with yanked text as initial search term
- Yanked text is automatically cleaned (newlines removed, whitespace trimmed) for better search experience
- Added validation to notify user if yank register is empty
- Cleaned up some unused keybindings and improved code formatting

**Benefits:**
- Streamlines workflow when you need to search for copied text
- Reduces manual typing when searching for function names, variables, or text snippets
- Provides both grep and file search options for flexibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clipboard-based search: grep yanked text and find files using clipboard content with automatic whitespace normalization.

* **Changes**
  * Updated fuzzy sorting for file/search results for improved relevance.
  * Several keyboard shortcuts for file/search actions have been removed or reorganized; a few file/grep mappings were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->