### PR TITLE
feat: add textlint for Japanese technical writing validation

### DIFF
--- a/config/nix/configs/textlint.nix
+++ b/config/nix/configs/textlint.nix
@@ -1,0 +1,7 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    (textlint.withPackages [ textlint-rule-preset-ja-technical-writing ])
+  ];
+}

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -36,6 +36,7 @@
     ./configs/rust.nix
     ./configs/database.nix
     ./configs/mcp-servers.nix
+    ./configs/textlint.nix
   ];
 
   # Home Manager can also manage your environment variables through


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR adds textlint with the Japanese technical writing preset to validate Japanese documentation and technical writing.

**Changes:**
- Added `config/nix/configs/textlint.nix` with textlint package and `textlint-rule-preset-ja-technical-writing` preset
- Updated `config/nix/home.nix` to import the new textlint configuration

**Benefits:**
- Enables automated validation of Japanese technical documentation
- Helps maintain consistent writing style and quality in Japanese content
- Integrates with existing Nix home-manager configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added textlint text linting tool with Japanese technical writing preset to the development environment for enhanced documentation quality, consistency, and adherence to writing standards and best practices.
  * Integrated linting tool configuration through Home Manager package management system for standardized, reproducible developer environment setup across the team and all development machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->