### PR TITLE
feat: add GitHub CLI (gh) configuration to nix setup

### DIFF
--- a/config/nix/configs/git.nix
+++ b/config/nix/configs/git.nix
@@ -15,4 +15,11 @@
       };
     };
   };
+
+  programs.gh = {
+    enable = true;
+    settings = {
+      git_protocol = "ssh";
+    };
+  };
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR adds GitHub CLI (`gh`) configuration to the Nix home-manager setup.

**Changes:**
- Enabled `programs.gh` in the git configuration
- Set `git_protocol` to `ssh` for GitHub CLI operations

**Benefits:**
- Provides native GitHub CLI support in the development environment
- Ensures gh uses SSH protocol for git operations, consistent with the existing git configuration
- Simplifies GitHub-related operations (PR creation, issue management, etc.) from the command line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled GitHub CLI support
  * Configured SSH as the default protocol for Git operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->