### PR TITLE
chore: add Renovate trigger comment to flake.nix

### DIFF
--- a/config/nix/flake.nix
+++ b/config/nix/flake.nix
@@ -1,3 +1,5 @@
+# https://github.com/renovatebot/renovate/issues/29721
+# Trick renovate into working: "github:NixOS/nixpkgs/nixpkgs-unstable"
 {
   description = "Home Manager configuration";
 


### PR DESCRIPTION
### 🔗 Linked issue

Relates to https://github.com/renovatebot/renovate/issues/29721

### 📚 Description

This PR adds comments to `flake.nix` to help Renovate bot detect and process Nix flake dependencies. The comments include a reference to the upstream Renovate issue and a trick to trigger Renovate's Nix support.

**Changes:**
- Added reference comment to Renovate issue #29721
- Added trick comment with nixpkgs reference: `"github:NixOS/nixpkgs/nixpkgs-unstable"`

This enables Renovate to properly track and update Nix flake inputs in the dotfiles repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration comments for internal tooling compatibility.

---

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->