### PR TITLE
chore: enable Renovate lock file maintenance for Nix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,9 @@
     "before 5am"
   ],
   "nix": {
-    "enabled": true
+    "enabled": true,
+    "lockFileMaintenance": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No specific issue -->

### 📚 Description

This PR enables Renovate's lock file maintenance feature for Nix dependencies to keep the flake.lock file up to date automatically.

Changes made:
- Updated GitHub Actions dependencies (checkout v4→v5, gh-actions-lua v11→v12, gh-actions-luarocks v5→v6)
- Added trigger comment in flake.nix to help Renovate detect Nix dependencies
- Enabled `lockFileMaintenance` in renovate.json for Nix configuration

This ensures that our Nix flake.lock file will be automatically maintained by Renovate alongside other dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to enable automatic lock file maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->