### PR TITLE
chore: disable Nix support in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "before 5am"
   ],
   "nix": {
-    "enabled": true,
+    "enabled": false,
     "lockFileMaintenance": {
       "enabled": true
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No specific issue -->

### 📚 Description

This PR temporarily disables Nix support in Renovate configuration to debug and investigate issues with Nix dependency updates.

Changes made:
- Set `enabled: false` for Nix in renovate.json
- Keep lockFileMaintenance configuration for future re-enabling

This change allows us to troubleshoot Renovate's Nix integration while maintaining other dependency update functionality.