### PR TITLE
Switch Docker from rootless to rootful mode

### DIFF
--- a/config/nix/nixos/configuration.nix
+++ b/config/nix/nixos/configuration.nix
@@ -28,6 +28,7 @@
     extraGroups = [
       "networkmanager"
       "wheel"
+      "docker"
     ];
     shell = pkgs.zsh;
   };
@@ -38,8 +39,8 @@
   # Enable nix-ld for dynamically linked executables (e.g. sass-embedded)
   programs.nix-ld.enable = true;
 
-  # Docker (rootless — no host-socket exposure, no docker group needed)
-  virtualisation.docker.rootless.enable = true;
+  # Docker
+  virtualisation.docker.enable = true;
 
   # Allow unfree packages
   nixpkgs.config.allowUnfree = true;


### PR DESCRIPTION
## Summary
- Switch from `virtualisation.docker.rootless.enable` to `virtualisation.docker.enable` for better compatibility
- Add user to `docker` group for socket access

## Test plan
- [x] Run `sudo nixos-rebuild switch` and verify Docker daemon starts
- [x] Verify `docker ps` works without `sudo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Docker service and configured user permissions to access Docker functionality.
  * Migrated Docker from rootless mode to standard daemon configuration for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->