### PR TITLE
Add AWS CLI package

### DIFF
--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -56,6 +56,7 @@
     ./programs/claude-code
     ./programs/textlint
     ./programs/agent-skills
+    ./programs/aws
   ];
 
   # Home Manager can also manage your environment variables through

--- a/config/nix/programs/aws/default.nix
+++ b/config/nix/programs/aws/default.nix
@@ -1,0 +1,7 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    awscli2
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `awscli2` package via new `programs/aws/default.nix` module
- Import the module in `home.nix`

## Test plan
- [x] Run `home-manager switch` and verify `aws --version` works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added AWS CLI v2 to the system configuration, making it available for use in the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->