### PR TITLE
Fix org-log skill: use --resume instead of --continue

### DIFF
--- a/config/claude/skills/org-log/SKILL.md
+++ b/config/claude/skills/org-log/SKILL.md
@@ -85,7 +85,7 @@ TITLE_SLUG=$(printf '%s' "$WORK_TITLE" \
 - 再開コマンド:
 #+begin_src shell
 cd {ワークスペースのディレクトリパス}
-claude --continue {セッションID}
+claude --resume {セッションID}
 #+end_src
 ```
 


### PR DESCRIPTION
## Summary
- Fix the claude CLI flag in org-log SKILL.md from `--continue` to `--resume`

## Test plan
- [x] Verify `/org-log` generates the correct `claude --resume` command in session logs