### PR TITLE
Add tmux configuration via home-manager

### DIFF
--- a/config/claude/statusline.sh
+++ b/config/claude/statusline.sh
@@ -9,7 +9,11 @@ eval "$(echo "$input" | jq -r '
 ')"
 
 if [ -n "$workspace_dir" ]; then
-  dir_name=$(echo "$workspace_dir" | sed "s|^$HOME|~|")
+  case "$workspace_dir" in
+    "$HOME") dir_name="~" ;;
+    "$HOME"/*) dir_name="~${workspace_dir#"$HOME"}" ;;
+    *) dir_name="$workspace_dir" ;;
+  esac
 else
   dir_name=""
 fi

--- a/config/claude/statusline.sh
+++ b/config/claude/statusline.sh
@@ -9,7 +9,7 @@ eval "$(echo "$input" | jq -r '
 ')"
 
 if [ -n "$workspace_dir" ]; then
-  dir_name=$(basename "$workspace_dir")
+  dir_name=$(echo "$workspace_dir" | sed "s|^$HOME|~|")
 else
   dir_name=""
 fi

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -56,6 +56,7 @@
     ./programs/claude-code
     ./programs/textlint
     ./programs/agent-skills
+    ./programs/tmux
   ];
 
   # Home Manager can also manage your environment variables through

--- a/config/nix/programs/tmux/default.nix
+++ b/config/nix/programs/tmux/default.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, ... }:
+
+{
+  programs.tmux = {
+    enable = true;
+    terminal = "tmux-256color";
+    prefix = "C-b";
+    baseIndex = 1;
+    escapeTime = 0;
+    keyMode = "vi";
+    mouse = true;
+    historyLimit = 10000;
+
+    extraConfig = ''
+      # True color support
+      set -ag terminal-overrides ",xterm-256color:RGB"
+
+      # Split panes with intuitive keys
+      bind | split-window -h -c "#{pane_current_path}"
+      bind - split-window -v -c "#{pane_current_path}"
+
+      # New window in current path
+      bind c new-window -c "#{pane_current_path}"
+
+      # Pane navigation with vim keys
+      bind h select-pane -L
+      bind j select-pane -D
+      bind k select-pane -U
+      bind l select-pane -R
+
+      # Pane resizing
+      bind -r H resize-pane -L 5
+      bind -r J resize-pane -D 5
+      bind -r K resize-pane -U 5
+      bind -r L resize-pane -R 5
+
+      # Reload config
+      bind r source-file ~/.tmux.conf \; display "Config reloaded"
+    '';
+  };
+}

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -21,6 +21,11 @@
     '';
 
     initContent = ''
+      # Auto-start tmux on WSL launch
+      if command -v tmux &> /dev/null && [ -z "$TMUX" ] && [ -z "$INSIDE_EMACS" ] && [ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]; then
+        exec tmux new-session -A -s main -c "$HOME/ghq/github.com/mikinovation/org"
+      fi
+
       # Enable Powerlevel10k instant prompt
       if [[ -r "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh" ]]; then
         source "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh"

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -22,8 +22,12 @@
 
     initContent = ''
       # Auto-start tmux on WSL launch
-      if command -v tmux &> /dev/null && [ -z "$TMUX" ] && [ -z "$INSIDE_EMACS" ] && [ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]; then
-        exec tmux new-session -A -s main -c "$HOME/ghq/github.com/mikinovation/org"
+      if grep -qi microsoft /proc/version 2>/dev/null \
+        && command -v tmux &> /dev/null \
+        && [ -z "$TMUX" ] && [ -z "$INSIDE_EMACS" ] && [ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]; then
+        TMUX_START_DIR="$HOME/ghq/github.com/mikinovation/org"
+        [ -d "$TMUX_START_DIR" ] || TMUX_START_DIR="$HOME"
+        exec tmux new-session -A -s main -c "$TMUX_START_DIR"
       fi
 
       # Enable Powerlevel10k instant prompt

--- a/config/nvim/plugins/orgmode/keymaps.lua
+++ b/config/nvim/plugins/orgmode/keymaps.lua
@@ -1,8 +1,36 @@
 local M = {}
 
+--- Get the :DIR: property value from the current org heading
+local function get_dir_property()
+	local orgmode = require("orgmode")
+	local closest = orgmode.files:get_closest_headline()
+	if not closest then
+		return nil
+	end
+	local dir = closest:get_property("DIR")
+	if dir then
+		return dir
+	end
+	return nil
+end
+
 function M.setup()
 	local org_dir = "~/ghq/github.com/mikinovation/org"
 	vim.keymap.set("n", "<leader>or", "<cmd>edit " .. org_dir .. "/refile.org<CR>", { desc = "Open refile.org" })
+	vim.keymap.set("n", "<leader>ov", function()
+		local dir = get_dir_property()
+		if not dir then
+			vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
+			return
+		end
+		local expanded = vim.fn.expand(dir)
+		if vim.fn.isdirectory(expanded) == 0 then
+			vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
+			return
+		end
+		vim.fn.system({ "tmux", "split-window", "-hb", "-c", expanded, "nvim" })
+		vim.notify("Opened nvim in left pane: " .. expanded)
+	end, { desc = "Open nvim in left tmux pane at :DIR:" })
 end
 
 return M

--- a/config/nvim/plugins/orgmode/keymaps.lua
+++ b/config/nvim/plugins/orgmode/keymaps.lua
@@ -28,8 +28,20 @@ function M.setup()
 			vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
 			return
 		end
+		if vim.fn.executable("tmux") ~= 1 then
+			vim.notify("tmux is not installed", vim.log.levels.ERROR)
+			return
+		end
+		if not vim.env.TMUX then
+			vim.notify("Not inside a tmux session", vim.log.levels.ERROR)
+			return
+		end
 		vim.fn.system({ "tmux", "split-window", "-hb", "-c", expanded, "nvim" })
-		vim.notify("Opened nvim in left pane: " .. expanded)
+		if vim.v.shell_error ~= 0 then
+			vim.notify("Failed to open tmux pane at: " .. expanded, vim.log.levels.ERROR)
+			return
+		end
+		vim.notify("Opened nvim in left pane: " .. expanded, vim.log.levels.INFO)
 	end, { desc = "Open nvim in left tmux pane at :DIR:" })
 end
 


### PR DESCRIPTION
## Summary
- Add `programs/tmux/default.nix` with tmux configuration
- Vi keybindings, mouse support, intuitive split keys (`|` / `-`), vim-style pane navigation

## Test plan
- [x] Run `home-manager switch` and verify tmux launches with the configured settings
- [x] Verify pane split (`|`, `-`) and navigation (`h/j/k/l`) work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic tmux session initialization on terminal startup
  * New Neovim keymap to open editor splits in tmux from org-mode documents

* **Improvements**
  * Statusline now displays full relative directory paths instead of only the final segment
  * Tmux now configured with enhanced key bindings, mouse support, and terminal optimizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->