### PR TITLE
Remove Notion MCP plugin from claude-code config

### DIFF
--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -6,7 +6,6 @@
 
 {
   mcp-servers.programs = {
-    playwright.enable = true;
     context7.enable = true;
     nixos.enable = true;
     terraform.enable = true;

--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -9,7 +9,6 @@
     playwright.enable = true;
     context7.enable = true;
     nixos.enable = true;
-    notion.enable = true;
     terraform.enable = true;
   };
 


### PR DESCRIPTION
## Summary
- Remove `notion.enable = true` from claude-code MCP plugin configuration

## Test plan
- [ ] Verify claude-code starts without errors after removing the Notion plugin