### PR TITLE
Add org-mode tmux integration keymaps for Claude, nvim, and terminal

### DIFF
--- a/config/nvim/plugins/orgmode/keymaps.lua
+++ b/config/nvim/plugins/orgmode/keymaps.lua
@@ -1,48 +1,139 @@
 local M = {}
 
---- Get the :DIR: property value from the current org heading
-local function get_dir_property()
+--- Get a property value from the current org heading
+local function get_heading_property(name)
 	local orgmode = require("orgmode")
 	local closest = orgmode.files:get_closest_headline()
 	if not closest then
 		return nil
 	end
-	local dir = closest:get_property("DIR")
-	if dir then
-		return dir
+	return closest:get_property(name)
+end
+
+--- Resolve :DIR: property to an expanded path, returns nil on failure
+local function resolve_dir()
+	local dir = get_heading_property("DIR")
+	if not dir then
+		vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
+		return nil
 	end
-	return nil
+	local expanded = vim.fn.expand(dir)
+	if vim.fn.isdirectory(expanded) == 0 then
+		vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
+		return nil
+	end
+	return expanded
+end
+
+--- Validate tmux availability; returns true if usable
+local function check_tmux()
+	if vim.fn.executable("tmux") ~= 1 then
+		vim.notify("tmux is not installed", vim.log.levels.ERROR)
+		return false
+	end
+	if not vim.env.TMUX then
+		vim.notify("Not inside a tmux session", vim.log.levels.ERROR)
+		return false
+	end
+	return true
+end
+
+--- Close all panes except the current one (keep max 2 panes)
+local function close_other_panes()
+	local count = tonumber(vim.fn.system("tmux list-panes | wc -l"))
+	if count and count >= 2 then
+		vim.fn.system({ "tmux", "kill-pane", "-a" })
+	end
+end
+
+--- Open a tmux split pane with the given command args
+local function open_tmux_pane(split_args, success_msg, error_msg)
+	if not check_tmux() then
+		return
+	end
+	close_other_panes()
+	vim.fn.system(split_args)
+	if vim.v.shell_error ~= 0 then
+		vim.notify(error_msg, vim.log.levels.ERROR)
+		return
+	end
+	vim.notify(success_msg, vim.log.levels.INFO)
+end
+
+--- Open nvim in left tmux pane at :DIR:
+local function open_nvim_pane()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-hb", "-c", dir, "nvim" },
+		"Opened nvim in left pane: " .. dir,
+		"Failed to open tmux pane at: " .. dir
+	)
+end
+
+--- Resume Claude session in right tmux pane from :SESSION_ID:
+local function resume_claude_session()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	local session_id = get_heading_property("SESSION_ID")
+	if not session_id then
+		vim.notify("No :SESSION_ID: property found in current heading", vim.log.levels.WARN)
+		return
+	end
+	if vim.fn.executable("claude") ~= 1 then
+		vim.notify("claude is not installed", vim.log.levels.ERROR)
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-h", "-c", dir, "claude", "--resume", session_id },
+		"Resumed Claude session in right pane: " .. session_id,
+		"Failed to resume Claude session: " .. session_id
+	)
+end
+
+--- Send visual selection to Claude Code in right tmux pane
+local function send_prompt_to_claude()
+	if not check_tmux() then
+		return
+	end
+	vim.cmd('normal! "vy')
+	local text = vim.fn.getreg("v")
+	if not text or text == "" then
+		vim.notify("No text selected", vim.log.levels.WARN)
+		return
+	end
+	vim.fn.system({ "tmux", "send-keys", "-t", "{right}", text, "Enter" })
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to send prompt to right pane", vim.log.levels.ERROR)
+		return
+	end
+	vim.notify("Sent prompt to Claude Code", vim.log.levels.INFO)
+end
+
+--- Open terminal in left tmux pane at :DIR:
+local function open_terminal_pane()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-hb", "-c", dir },
+		"Opened terminal in left pane: " .. dir,
+		"Failed to open terminal at: " .. dir
+	)
 end
 
 function M.setup()
 	local org_dir = "~/ghq/github.com/mikinovation/org"
 	vim.keymap.set("n", "<leader>or", "<cmd>edit " .. org_dir .. "/refile.org<CR>", { desc = "Open refile.org" })
-	vim.keymap.set("n", "<leader>ov", function()
-		local dir = get_dir_property()
-		if not dir then
-			vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
-			return
-		end
-		local expanded = vim.fn.expand(dir)
-		if vim.fn.isdirectory(expanded) == 0 then
-			vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
-			return
-		end
-		if vim.fn.executable("tmux") ~= 1 then
-			vim.notify("tmux is not installed", vim.log.levels.ERROR)
-			return
-		end
-		if not vim.env.TMUX then
-			vim.notify("Not inside a tmux session", vim.log.levels.ERROR)
-			return
-		end
-		vim.fn.system({ "tmux", "split-window", "-hb", "-c", expanded, "nvim" })
-		if vim.v.shell_error ~= 0 then
-			vim.notify("Failed to open tmux pane at: " .. expanded, vim.log.levels.ERROR)
-			return
-		end
-		vim.notify("Opened nvim in left pane: " .. expanded, vim.log.levels.INFO)
-	end, { desc = "Open nvim in left tmux pane at :DIR:" })
+	vim.keymap.set("n", "<leader>ov", open_nvim_pane, { desc = "Open nvim in left tmux pane at :DIR:" })
+	vim.keymap.set("n", "<leader>oC", resume_claude_session, { desc = "Resume Claude session in right tmux pane" })
+	vim.keymap.set("v", "<leader>op", send_prompt_to_claude, { desc = "Send selection to Claude Code" })
+	vim.keymap.set("n", "<leader>oT", open_terminal_pane, { desc = "Open terminal in left tmux pane at :DIR:" })
 end
 
 return M

--- a/config/nvim/plugins/orgmode/keymaps.lua
+++ b/config/nvim/plugins/orgmode/keymaps.lua
@@ -13,7 +13,7 @@ end
 --- Resolve :DIR: property to an expanded path, returns nil on failure
 local function resolve_dir()
 	local dir = get_heading_property("DIR")
-	if not dir then
+	if not dir or vim.trim(dir) == "" then
 		vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
 		return nil
 	end
@@ -80,7 +80,7 @@ local function resume_claude_session()
 		return
 	end
 	local session_id = get_heading_property("SESSION_ID")
-	if not session_id then
+	if not session_id or vim.trim(session_id) == "" then
 		vim.notify("No :SESSION_ID: property found in current heading", vim.log.levels.WARN)
 		return
 	end
@@ -100,8 +100,18 @@ local function send_prompt_to_claude()
 	if not check_tmux() then
 		return
 	end
-	vim.cmd('normal! "vy')
-	local text = vim.fn.getreg("v")
+	local srow, scol = unpack(vim.api.nvim_buf_get_mark(0, "<"))
+	local erow, ecol = unpack(vim.api.nvim_buf_get_mark(0, ">"))
+	if srow == 0 or erow == 0 then
+		vim.notify("No text selected", vim.log.levels.WARN)
+		return
+	end
+	if (srow > erow) or (srow == erow and scol > ecol) then
+		srow, erow = erow, srow
+		scol, ecol = ecol, scol
+	end
+	local lines = vim.api.nvim_buf_get_text(0, srow - 1, scol, erow - 1, ecol + 1, {})
+	local text = table.concat(lines, "\n")
 	if not text or text == "" then
 		vim.notify("No text selected", vim.log.levels.WARN)
 		return
@@ -130,10 +140,19 @@ end
 function M.setup()
 	local org_dir = "~/ghq/github.com/mikinovation/org"
 	vim.keymap.set("n", "<leader>or", "<cmd>edit " .. org_dir .. "/refile.org<CR>", { desc = "Open refile.org" })
-	vim.keymap.set("n", "<leader>ov", open_nvim_pane, { desc = "Open nvim in left tmux pane at :DIR:" })
-	vim.keymap.set("n", "<leader>oC", resume_claude_session, { desc = "Resume Claude session in right tmux pane" })
-	vim.keymap.set("v", "<leader>op", send_prompt_to_claude, { desc = "Send selection to Claude Code" })
-	vim.keymap.set("n", "<leader>oT", open_terminal_pane, { desc = "Open terminal in left tmux pane at :DIR:" })
+
+	vim.api.nvim_create_autocmd("FileType", {
+		pattern = "org",
+		callback = function(ev)
+			local opts = function(desc)
+				return { buffer = ev.buf, desc = desc }
+			end
+			vim.keymap.set("n", "<leader>ov", open_nvim_pane, opts("Open nvim in left tmux pane at :DIR:"))
+			vim.keymap.set("n", "<leader>oC", resume_claude_session, opts("Resume Claude session in right tmux pane"))
+			vim.keymap.set("v", "<leader>op", send_prompt_to_claude, opts("Send selection to Claude Code"))
+			vim.keymap.set("n", "<leader>oT", open_terminal_pane, opts("Open terminal in left tmux pane at :DIR:"))
+		end,
+	})
 end
 
 return M


### PR DESCRIPTION
## Summary
- Add keymaps to open nvim (`<leader>ov`), resume Claude session (`<leader>oC`), send prompt to Claude (`<leader>op`), and open terminal (`<leader>oT`) from org heading `:DIR:` / `:SESSION_ID:` properties
- Enforce max 2 tmux panes by closing existing panes before opening new splits
- Refactor: extract inline keymap logic into named functions for readability

## Test plan
- [x] Open an org file with `:DIR:` and `:SESSION_ID:` properties
- [x] Verify `<leader>ov` opens nvim in left tmux pane at the `:DIR:` path
- [x] Verify `<leader>oC` resumes Claude session in right tmux pane
- [x] Verify `<leader>op` sends visual selection to the right pane
- [x] Verify `<leader>oT` opens terminal in left tmux pane
- [x] Verify opening a new pane closes the existing non-org pane (max 2 panes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keybinding to resume Claude sessions in the right pane
  * Visual-mode keybinding to send selected text to the right pane
  * Keybinding to open a terminal split in the left pane

* **Improvements**
  * Generalized heading property access and improved directory resolution
  * Robust checks and user notifications for missing tools, sessions, directories, and command errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->