### PR TITLE
Refactor: Extract action logic from keymaps into dedicated modules

### DIFF
--- a/config/nvim/actions.lua
+++ b/config/nvim/actions.lua
@@ -1,0 +1,24 @@
+-- actions.lua
+-- Global action functions invoked by keymaps.
+-- Keep keymap files free of inline logic by defining actions here.
+
+local M = {}
+
+--- Format the current buffer using the active LSP client(s).
+function M.format_document()
+	vim.lsp.buf.format({ async = true })
+end
+
+--- Open the directory of the current file in Windows Explorer (WSL).
+function M.open_in_explorer()
+	local dir = vim.fn.expand("%:p:h")
+	local win_dir = vim.fn.system({ "wslpath", "-w", dir }):gsub("\n", "")
+	vim.fn.system({ "explorer.exe", win_dir })
+end
+
+--- Toggle the lazydocker floating terminal.
+function M.toggle_lazydocker()
+	require("tools.lazydocker").toggle_lazydocker()
+end
+
+return M

--- a/config/nvim/actions.lua
+++ b/config/nvim/actions.lua
@@ -12,8 +12,20 @@ end
 --- Open the directory of the current file in Windows Explorer (WSL).
 function M.open_in_explorer()
 	local dir = vim.fn.expand("%:p:h")
-	local win_dir = vim.fn.system({ "wslpath", "-w", dir }):gsub("\n", "")
+
+	local win_dir = vim.fn.system({ "wslpath", "-w", dir })
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to translate path via wslpath: " .. dir, vim.log.levels.ERROR)
+		return
+	end
+	-- wslpath output can include trailing \n or \r\n; strip all trailing whitespace.
+	win_dir = win_dir:gsub("%s+$", "")
+
 	vim.fn.system({ "explorer.exe", win_dir })
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to open Windows Explorer at: " .. win_dir, vim.log.levels.ERROR)
+		return
+	end
 end
 
 --- Toggle the lazydocker floating terminal.

--- a/config/nvim/actions_spec.lua
+++ b/config/nvim/actions_spec.lua
@@ -1,0 +1,129 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+-- Resolve the directory containing this spec file.
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local nvim_dir = spec_dir()
+
+local lazydocker_calls
+local system_calls
+
+local function setup_vim_mock()
+	system_calls = {}
+	_G.vim = {
+		fn = {
+			expand = function(s)
+				if s == "%:p:h" then
+					return "/home/u/project/src"
+				end
+				return s
+			end,
+			system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[1] == "wslpath" then
+					return "C:\\home\\u\\project\\src\n"
+				end
+				return ""
+			end,
+		},
+		lsp = {
+			buf = {
+				format_calls = {},
+				format = function(opts)
+					table.insert(_G.vim.lsp.buf.format_calls, opts)
+				end,
+			},
+		},
+	}
+end
+
+describe("actions (global)", function()
+	local saved_vim, saved_path, saved_lazydocker
+
+	setup(function()
+		saved_vim = _G.vim
+		saved_path = package.path
+		saved_lazydocker = package.loaded["tools.lazydocker"]
+		package.path = nvim_dir .. "?.lua;" .. nvim_dir .. "?/init.lua;" .. package.path
+	end)
+
+	teardown(function()
+		_G.vim = saved_vim
+		package.path = saved_path
+		package.loaded["tools.lazydocker"] = saved_lazydocker
+		package.loaded["actions"] = nil
+	end)
+
+	before_each(function()
+		setup_vim_mock()
+		lazydocker_calls = 0
+		package.loaded["tools.lazydocker"] = {
+			toggle_lazydocker = function()
+				lazydocker_calls = lazydocker_calls + 1
+			end,
+		}
+		package.loaded["actions"] = nil
+	end)
+
+	describe("format_document", function()
+		it("calls vim.lsp.buf.format with async = true", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.format_document()
+			assert.equals(1, #_G.vim.lsp.buf.format_calls)
+			assert.same({ async = true }, _G.vim.lsp.buf.format_calls[1])
+		end)
+	end)
+
+	describe("open_in_explorer", function()
+		it("translates the buffer's directory via wslpath then opens explorer.exe", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.open_in_explorer()
+
+			assert.equals(2, #system_calls, "should invoke wslpath and explorer.exe")
+			assert.same({ "wslpath", "-w", "/home/u/project/src" }, system_calls[1])
+			assert.same({ "explorer.exe", "C:\\home\\u\\project\\src" }, system_calls[2])
+		end)
+
+		it("strips the trailing newline from the wslpath output", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.open_in_explorer()
+			-- The second call's path argument should not contain a newline
+			assert.is_nil(system_calls[2][2]:find("\n"))
+		end)
+	end)
+
+	describe("toggle_lazydocker", function()
+		it("delegates to tools.lazydocker.toggle_lazydocker", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.toggle_lazydocker()
+			assert.equals(1, lazydocker_calls)
+		end)
+
+		it("can be invoked multiple times", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.toggle_lazydocker()
+			actions.toggle_lazydocker()
+			assert.equals(2, lazydocker_calls)
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports the documented public functions", function()
+			local actions = dofile(nvim_dir .. "actions.lua")
+			assert.is_function(actions.format_document)
+			assert.is_function(actions.open_in_explorer)
+			assert.is_function(actions.toggle_lazydocker)
+		end)
+	end)
+end)

--- a/config/nvim/actions_spec.lua
+++ b/config/nvim/actions_spec.lua
@@ -18,9 +18,11 @@ local nvim_dir = spec_dir()
 
 local lazydocker_calls
 local system_calls
+local notify_calls
 
 local function setup_vim_mock()
 	system_calls = {}
+	notify_calls = {}
 	_G.vim = {
 		fn = {
 			expand = function(s)
@@ -37,6 +39,11 @@ local function setup_vim_mock()
 				return ""
 			end,
 		},
+		v = { shell_error = 0 },
+		log = { levels = { WARN = 2, ERROR = 4, INFO = 1 } },
+		notify = function(msg, level)
+			table.insert(notify_calls, { msg = msg, level = level })
+		end,
 		lsp = {
 			buf = {
 				format_calls = {},
@@ -93,13 +100,60 @@ describe("actions (global)", function()
 			assert.equals(2, #system_calls, "should invoke wslpath and explorer.exe")
 			assert.same({ "wslpath", "-w", "/home/u/project/src" }, system_calls[1])
 			assert.same({ "explorer.exe", "C:\\home\\u\\project\\src" }, system_calls[2])
+			assert.equals(0, #notify_calls, "happy path should not notify")
 		end)
 
-		it("strips the trailing newline from the wslpath output", function()
+		it("strips trailing whitespace from the wslpath output (handles \\n and \\r\\n)", function()
+			_G.vim.fn.system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[1] == "wslpath" then
+					return "C:\\home\\u\\project\\src\r\n"
+				end
+				return ""
+			end
 			local actions = dofile(nvim_dir .. "actions.lua")
 			actions.open_in_explorer()
-			-- The second call's path argument should not contain a newline
-			assert.is_nil(system_calls[2][2]:find("\n"))
+			local win_dir_arg = system_calls[2][2]
+			assert.is_nil(win_dir_arg:find("[\r\n]"))
+			assert.is_nil(win_dir_arg:find("%s$"))
+		end)
+
+		it("notifies and aborts when wslpath fails", function()
+			_G.vim.fn.system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[1] == "wslpath" then
+					_G.vim.v.shell_error = 1
+					return ""
+				end
+				return ""
+			end
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.open_in_explorer()
+
+			assert.equals(1, #system_calls, "should not invoke explorer.exe after wslpath failure")
+			assert.equals(1, #notify_calls)
+			assert.equals(_G.vim.log.levels.ERROR, notify_calls[1].level)
+			assert.truthy(notify_calls[1].msg:find("wslpath"))
+		end)
+
+		it("notifies when explorer.exe fails", function()
+			_G.vim.fn.system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[1] == "wslpath" then
+					return "C:\\home\\u\\project\\src\n"
+				end
+				if type(args) == "table" and args[1] == "explorer.exe" then
+					_G.vim.v.shell_error = 1
+				end
+				return ""
+			end
+			local actions = dofile(nvim_dir .. "actions.lua")
+			actions.open_in_explorer()
+
+			assert.equals(2, #system_calls)
+			assert.equals(1, #notify_calls)
+			assert.equals(_G.vim.log.levels.ERROR, notify_calls[1].level)
+			assert.truthy(notify_calls[1].msg:find("Explorer"))
 		end)
 	end)
 

--- a/config/nvim/actions_spec.lua
+++ b/config/nvim/actions_spec.lua
@@ -56,12 +56,13 @@ local function setup_vim_mock()
 end
 
 describe("actions (global)", function()
-	local saved_vim, saved_path, saved_lazydocker
+	local saved_vim, saved_path, saved_lazydocker, saved_actions
 
 	setup(function()
 		saved_vim = _G.vim
 		saved_path = package.path
 		saved_lazydocker = package.loaded["tools.lazydocker"]
+		saved_actions = package.loaded["actions"]
 		package.path = nvim_dir .. "?.lua;" .. nvim_dir .. "?/init.lua;" .. package.path
 	end)
 
@@ -69,7 +70,7 @@ describe("actions (global)", function()
 		_G.vim = saved_vim
 		package.path = saved_path
 		package.loaded["tools.lazydocker"] = saved_lazydocker
-		package.loaded["actions"] = nil
+		package.loaded["actions"] = saved_actions
 	end)
 
 	before_each(function()

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -14,6 +14,4 @@ require("lsp")
 require("keymaps")
 
 -- Create user command for lazydocker
-vim.api.nvim_create_user_command("Lazydocker", function()
-	require("tools.lazydocker").toggle_lazydocker()
-end, {})
+vim.api.nvim_create_user_command("Lazydocker", require("actions").toggle_lazydocker, {})

--- a/config/nvim/keymaps.lua
+++ b/config/nvim/keymaps.lua
@@ -1,31 +1,23 @@
-local keymap = vim.keymap.set
+-- keymaps.lua
+-- Global keymaps. This file contains only key bindings.
+-- All non-trivial logic lives in actions.lua (or other modules).
 
-keymap("n", "<Esc>", "<cmd>nohlsearch<CR>")
-keymap("n", "<leader>dl", vim.diagnostic.setloclist, { desc = "Open diagnostics in loclist" })
-keymap("n", "<leader>df", vim.diagnostic.open_float, { desc = "Open diagnostics in float" })
-keymap("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
-keymap("n", "<C-h>", "<C-w><C-h>", { desc = "Move focus to the left window" })
-keymap("n", "<C-l>", "<C-w><C-l>", { desc = "Move focus to the right window" })
-keymap("n", "<C-j>", "<C-w><C-j>", { desc = "Move focus to the lower window" })
-keymap("n", "<C-k>", "<C-w><C-k>", { desc = "Move focus to the upper window" })
+local actions = require("actions")
+local map = vim.keymap.set
 
-keymap("n", "<leader>rm", ":%s/\r//g<CR>", { desc = "Remove ^M" })
+map("n", "<Esc>", "<cmd>nohlsearch<CR>")
+map("n", "<leader>dl", vim.diagnostic.setloclist, { desc = "Open diagnostics in loclist" })
+map("n", "<leader>df", vim.diagnostic.open_float, { desc = "Open diagnostics in float" })
+map("t", "<Esc><Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
+map("n", "<C-h>", "<C-w><C-h>", { desc = "Move focus to the left window" })
+map("n", "<C-l>", "<C-w><C-l>", { desc = "Move focus to the right window" })
+map("n", "<C-j>", "<C-w><C-j>", { desc = "Move focus to the lower window" })
+map("n", "<C-k>", "<C-w><C-k>", { desc = "Move focus to the upper window" })
 
-keymap("i", "jj", "<Esc>", { noremap = true, silent = true })
+map("n", "<leader>rm", ":%s/\r//g<CR>", { desc = "Remove ^M" })
 
--- Format with LSP/null-ls (ESLint, etc.)
-keymap("n", "<leader>fm", function()
-	vim.lsp.buf.format({ async = true })
-end, { desc = "Format document" })
+map("i", "jj", "<Esc>", { noremap = true, silent = true })
 
--- Open current file's directory in Windows Explorer
-keymap("n", "<leader>fe", function()
-	local dir = vim.fn.expand("%:p:h")
-	local win_dir = vim.fn.system({ "wslpath", "-w", dir }):gsub("\n", "")
-	vim.fn.system({ "explorer.exe", win_dir })
-end, { desc = "Open in Windows Explorer" })
-
--- Lazydocker integration
-keymap("n", "<leader>ld", function()
-	require("tools.lazydocker").toggle_lazydocker()
-end, { desc = "Toggle lazydocker" })
+map("n", "<leader>fm", actions.format_document, { desc = "Format document" })
+map("n", "<leader>fe", actions.open_in_explorer, { desc = "Open in Windows Explorer" })
+map("n", "<leader>ld", actions.toggle_lazydocker, { desc = "Toggle lazydocker" })

--- a/config/nvim/lsp/actions.lua
+++ b/config/nvim/lsp/actions.lua
@@ -1,0 +1,11 @@
+-- lsp/actions.lua
+-- LSP-related action functions invoked by buffer-local keymaps.
+
+local M = {}
+
+--- Asynchronously format the current buffer via the active LSP client(s).
+function M.format_document()
+	vim.lsp.buf.format({ async = true })
+end
+
+return M

--- a/config/nvim/lsp/actions_spec.lua
+++ b/config/nvim/lsp/actions_spec.lua
@@ -1,0 +1,58 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local lsp_dir = spec_dir()
+
+describe("lsp.actions", function()
+	local saved_vim
+	local format_calls
+
+	setup(function()
+		saved_vim = _G.vim
+	end)
+
+	teardown(function()
+		_G.vim = saved_vim
+	end)
+
+	before_each(function()
+		format_calls = {}
+		_G.vim = {
+			lsp = {
+				buf = {
+					format = function(opts)
+						table.insert(format_calls, opts)
+					end,
+				},
+			},
+		}
+	end)
+
+	describe("format_document", function()
+		it("calls vim.lsp.buf.format with async = true", function()
+			local actions = dofile(lsp_dir .. "actions.lua")
+			actions.format_document()
+			assert.equals(1, #format_calls)
+			assert.same({ async = true }, format_calls[1])
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports format_document", function()
+			local actions = dofile(lsp_dir .. "actions.lua")
+			assert.is_function(actions.format_document)
+		end)
+	end)
+end)

--- a/config/nvim/lsp/keymaps.lua
+++ b/config/nvim/lsp/keymaps.lua
@@ -1,12 +1,14 @@
 -- lsp/keymaps.lua
+-- Buffer-local LSP keymaps. This file contains only key bindings.
+-- All non-trivial logic lives in lsp/actions.lua (or other modules).
 
--- Keybinding settings for LSP attach
 vim.api.nvim_create_autocmd("LspAttach", {
 	group = vim.api.nvim_create_augroup("UserLspConfig", { clear = true }),
 	callback = function(event)
 		local client = vim.lsp.get_client_by_id(event.data.client_id)
 		local bufnr = event.buf
 		local builtin = require("telescope.builtin")
+		local actions = require("lsp.actions")
 
 		-- Enable completion triggered by <c-x><c-o>
 		vim.bo[bufnr].omnifunc = "v:lua.vim.lsp.omnifunc"
@@ -16,7 +18,6 @@ vim.api.nvim_create_autocmd("LspAttach", {
 			vim.keymap.set("n", keys, func, { buffer = bufnr, desc = "LSP: " .. desc })
 		end
 
-		-- Keymappings for commonly used features
 		map("gd", builtin.lsp_definitions, "[G]oto [D]efinition")
 		map("gr", builtin.lsp_references, "[G]oto [R]eferences")
 		map("gI", builtin.lsp_implementations, "[G]oto [I]mplementation")
@@ -35,11 +36,9 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		map("]d", vim.diagnostic.goto_next, "Next [D]iagnostic")
 		map("<leader>q", vim.diagnostic.setloclist, "Diagnostics to [L]ocation List")
 
-		-- Format document
+		-- Format document (only when supported by the attached client)
 		if client and client:supports_method("textDocument/formatting") then
-			map("<leader>f", function()
-				vim.lsp.buf.format({ async = true })
-			end, "[F]ormat document")
+			map("<leader>f", actions.format_document, "[F]ormat document")
 		end
 	end,
 })

--- a/config/nvim/plugins/gitlinker/actions.lua
+++ b/config/nvim/plugins/gitlinker/actions.lua
@@ -1,0 +1,10 @@
+-- plugins/gitlinker/actions.lua
+
+local M = {}
+
+--- Copy a git-host URL for the current buffer/range to the clipboard.
+function M.copy_git_link()
+	require("gitlinker").get_buf_range_url("n")
+end
+
+return M

--- a/config/nvim/plugins/gitlinker/actions_spec.lua
+++ b/config/nvim/plugins/gitlinker/actions_spec.lua
@@ -1,0 +1,54 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local actions_dir = spec_dir()
+
+describe("plugins.gitlinker.actions", function()
+	local saved_gitlinker
+	local get_buf_range_url_calls
+
+	setup(function()
+		saved_gitlinker = package.loaded["gitlinker"]
+	end)
+
+	teardown(function()
+		package.loaded["gitlinker"] = saved_gitlinker
+	end)
+
+	before_each(function()
+		get_buf_range_url_calls = {}
+		package.loaded["gitlinker"] = {
+			get_buf_range_url = function(mode)
+				table.insert(get_buf_range_url_calls, mode)
+			end,
+		}
+	end)
+
+	describe("copy_git_link", function()
+		it("calls gitlinker.get_buf_range_url with normal mode", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			actions.copy_git_link()
+			assert.equals(1, #get_buf_range_url_calls)
+			assert.equals("n", get_buf_range_url_calls[1])
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports copy_git_link", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			assert.is_function(actions.copy_git_link)
+		end)
+	end)
+end)

--- a/config/nvim/plugins/gitlinker/keymaps.lua
+++ b/config/nvim/plugins/gitlinker/keymaps.lua
@@ -1,9 +1,8 @@
 local M = {}
 
 function M.setup()
-	vim.keymap.set("n", "<leader>gy", function()
-		require("gitlinker").get_buf_range_url("n")
-	end, { desc = "Copy git link to clipboard" })
+	local actions = require("plugins.gitlinker.actions")
+	vim.keymap.set("n", "<leader>gy", actions.copy_git_link, { desc = "Copy git link to clipboard" })
 end
 
 return M

--- a/config/nvim/plugins/neotest/actions.lua
+++ b/config/nvim/plugins/neotest/actions.lua
@@ -1,0 +1,20 @@
+-- plugins/neotest/actions.lua
+
+local M = {}
+
+--- Run the test nearest to the cursor.
+function M.run_nearest()
+	require("neotest").run.run()
+end
+
+--- Run the test nearest to the cursor under the DAP debugger.
+function M.debug_nearest()
+	require("neotest").run.run({ strategy = "dap" })
+end
+
+--- Run all tests in the current file.
+function M.run_file()
+	require("neotest").run.run(vim.fn.expand("%"))
+end
+
+return M

--- a/config/nvim/plugins/neotest/actions_spec.lua
+++ b/config/nvim/plugins/neotest/actions_spec.lua
@@ -1,0 +1,90 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local actions_dir = spec_dir()
+
+describe("plugins.neotest.actions", function()
+	local saved_vim, saved_neotest
+	local run_calls
+
+	setup(function()
+		saved_vim = _G.vim
+		saved_neotest = package.loaded["neotest"]
+	end)
+
+	teardown(function()
+		_G.vim = saved_vim
+		package.loaded["neotest"] = saved_neotest
+	end)
+
+	before_each(function()
+		run_calls = {}
+		_G.vim = {
+			fn = {
+				expand = function(s)
+					if s == "%" then
+						return "/abs/path/test_spec.lua"
+					end
+					return s
+				end,
+			},
+		}
+		package.loaded["neotest"] = {
+			run = {
+				run = function(...)
+					table.insert(run_calls, { n = select("#", ...), arg = (select(1, ...)) })
+				end,
+			},
+		}
+	end)
+
+	describe("run_nearest", function()
+		it("invokes neotest.run.run with no argument", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			actions.run_nearest()
+			assert.equals(1, #run_calls)
+			assert.equals(0, run_calls[1].n, "should be called with zero arguments")
+		end)
+	end)
+
+	describe("debug_nearest", function()
+		it("invokes neotest.run.run with the dap strategy", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			actions.debug_nearest()
+			assert.equals(1, #run_calls)
+			assert.equals(1, run_calls[1].n)
+			assert.same({ strategy = "dap" }, run_calls[1].arg)
+		end)
+	end)
+
+	describe("run_file", function()
+		it("invokes neotest.run.run with the current buffer's file path", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			actions.run_file()
+			assert.equals(1, #run_calls)
+			assert.equals(1, run_calls[1].n)
+			assert.equals("/abs/path/test_spec.lua", run_calls[1].arg)
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports the documented public functions", function()
+			local actions = dofile(actions_dir .. "actions.lua")
+			assert.is_function(actions.run_nearest)
+			assert.is_function(actions.debug_nearest)
+			assert.is_function(actions.run_file)
+		end)
+	end)
+end)

--- a/config/nvim/plugins/neotest/keymaps.lua
+++ b/config/nvim/plugins/neotest/keymaps.lua
@@ -1,19 +1,12 @@
 local M = {}
 
 function M.setup()
-	vim.keymap.set("n", "<leader>tn", ":lua require('neotest').run.run()<CR>", { desc = "Run test nearest" })
-	vim.keymap.set(
-		"n",
-		"<leader>tD",
-		":lua require('neotest').run.run({strategy = 'dap'})<CR>",
-		{ desc = "Debug test nearest (DAP)" }
-	)
-	vim.keymap.set(
-		"n",
-		"<leader>tf",
-		":lua require('neotest').run.run(vim.fn.expand('%'))<CR>",
-		{ desc = "Run test file" }
-	)
+	local actions = require("plugins.neotest.actions")
+	local map = vim.keymap.set
+
+	map("n", "<leader>tn", actions.run_nearest, { desc = "Run test nearest" })
+	map("n", "<leader>tD", actions.debug_nearest, { desc = "Debug test nearest (DAP)" })
+	map("n", "<leader>tf", actions.run_file, { desc = "Run test file" })
 end
 
 return M

--- a/config/nvim/plugins/orgmode/actions.lua
+++ b/config/nvim/plugins/orgmode/actions.lua
@@ -1,0 +1,143 @@
+-- plugins/orgmode/actions.lua
+-- Action functions for orgmode keymaps. All non-trivial logic lives here.
+
+local M = {}
+
+--- Get a property value from the closest org heading.
+local function get_heading_property(name)
+	local orgmode = require("orgmode")
+	local closest = orgmode.files:get_closest_headline()
+	if not closest then
+		return nil
+	end
+	return closest:get_property(name)
+end
+
+--- Resolve the :DIR: property to an expanded path; returns nil with a notify on failure.
+local function resolve_dir()
+	local dir = get_heading_property("DIR")
+	if not dir or vim.trim(dir) == "" then
+		vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
+		return nil
+	end
+	local expanded = vim.fn.expand(dir)
+	if vim.fn.isdirectory(expanded) == 0 then
+		vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
+		return nil
+	end
+	return expanded
+end
+
+--- Validate tmux availability; returns true if usable.
+local function check_tmux()
+	if vim.fn.executable("tmux") ~= 1 then
+		vim.notify("tmux is not installed", vim.log.levels.ERROR)
+		return false
+	end
+	if not vim.env.TMUX then
+		vim.notify("Not inside a tmux session", vim.log.levels.ERROR)
+		return false
+	end
+	return true
+end
+
+--- Close all panes except the current one (keep max 2 panes).
+local function close_other_panes()
+	local count = tonumber(vim.fn.system("tmux list-panes | wc -l"))
+	if count and count >= 2 then
+		vim.fn.system({ "tmux", "kill-pane", "-a" })
+	end
+end
+
+--- Open a tmux split pane with the given command args.
+local function open_tmux_pane(split_args, success_msg, error_msg)
+	if not check_tmux() then
+		return
+	end
+	close_other_panes()
+	vim.fn.system(split_args)
+	if vim.v.shell_error ~= 0 then
+		vim.notify(error_msg, vim.log.levels.ERROR)
+		return
+	end
+	vim.notify(success_msg, vim.log.levels.INFO)
+end
+
+--- Open nvim in the left tmux pane at the heading's :DIR:.
+function M.open_nvim_pane()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-hb", "-c", dir, "nvim" },
+		"Opened nvim in left pane: " .. dir,
+		"Failed to open tmux pane at: " .. dir
+	)
+end
+
+--- Resume a Claude session in the right tmux pane using :SESSION_ID:.
+function M.resume_claude_session()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	local session_id = get_heading_property("SESSION_ID")
+	if not session_id or vim.trim(session_id) == "" then
+		vim.notify("No :SESSION_ID: property found in current heading", vim.log.levels.WARN)
+		return
+	end
+	if vim.fn.executable("claude") ~= 1 then
+		vim.notify("claude is not installed", vim.log.levels.ERROR)
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-h", "-c", dir, "claude", "--resume", session_id },
+		"Resumed Claude session in right pane: " .. session_id,
+		"Failed to resume Claude session: " .. session_id
+	)
+end
+
+--- Send the current visual selection to Claude Code in the right tmux pane.
+function M.send_prompt_to_claude()
+	if not check_tmux() then
+		return
+	end
+	local srow, scol = unpack(vim.api.nvim_buf_get_mark(0, "<"))
+	local erow, ecol = unpack(vim.api.nvim_buf_get_mark(0, ">"))
+	if srow == 0 or erow == 0 then
+		vim.notify("No text selected", vim.log.levels.WARN)
+		return
+	end
+	if (srow > erow) or (srow == erow and scol > ecol) then
+		srow, erow = erow, srow
+		scol, ecol = ecol, scol
+	end
+	local lines = vim.api.nvim_buf_get_text(0, srow - 1, scol, erow - 1, ecol + 1, {})
+	local text = table.concat(lines, "\n")
+	if not text or text == "" then
+		vim.notify("No text selected", vim.log.levels.WARN)
+		return
+	end
+	vim.fn.system({ "tmux", "send-keys", "-t", "{right}", text, "Enter" })
+	if vim.v.shell_error ~= 0 then
+		vim.notify("Failed to send prompt to right pane", vim.log.levels.ERROR)
+		return
+	end
+	vim.notify("Sent prompt to Claude Code", vim.log.levels.INFO)
+end
+
+--- Open a terminal in the left tmux pane at the heading's :DIR:.
+function M.open_terminal_pane()
+	local dir = resolve_dir()
+	if not dir then
+		return
+	end
+	open_tmux_pane(
+		{ "tmux", "split-window", "-hb", "-c", dir },
+		"Opened terminal in left pane: " .. dir,
+		"Failed to open terminal at: " .. dir
+	)
+end
+
+return M

--- a/config/nvim/plugins/orgmode/actions_spec.lua
+++ b/config/nvim/plugins/orgmode/actions_spec.lua
@@ -284,10 +284,11 @@ describe("plugins.orgmode.actions", function()
 			load_actions().send_prompt_to_claude()
 			local call = find_system_call({ "tmux", "send-keys" })
 			assert.is_not_nil(call)
-			-- target = {right}; payload = "hello"; suffix = "Enter"
-			assert.equals("{right}", call[3])
-			assert.equals("hello", call[4])
-			assert.equals("Enter", call[5])
+			-- tmux send-keys -t {right} <payload> Enter
+			assert.equals("-t", call[3])
+			assert.equals("{right}", call[4])
+			assert.equals("hello", call[5])
+			assert.equals("Enter", call[6])
 		end)
 
 		it("normalizes inverted marks (end before start) before extraction", function()

--- a/config/nvim/plugins/orgmode/actions_spec.lua
+++ b/config/nvim/plugins/orgmode/actions_spec.lua
@@ -1,0 +1,346 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local actions_dir = spec_dir()
+
+local notify_calls
+local system_calls
+local heading_props
+local has_heading
+local executables
+local marks
+
+local function setup_vim_mock()
+	notify_calls = {}
+	system_calls = {}
+	heading_props = {}
+	has_heading = true
+	executables = { tmux = true, claude = true }
+	marks = { ["<"] = { 1, 0 }, [">"] = { 1, 5 } }
+
+	_G.vim = {
+		fn = {
+			expand = function(s)
+				return s
+			end,
+			isdirectory = function()
+				return 1
+			end,
+			executable = function(name)
+				return executables[name] and 1 or 0
+			end,
+			system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "string" and args:match("list%-panes") then
+					return "1"
+				end
+				return ""
+			end,
+		},
+		api = {
+			nvim_buf_get_mark = function(_, mark)
+				return marks[mark]
+			end,
+			nvim_buf_get_text = function()
+				return { "hello" }
+			end,
+		},
+		env = { TMUX = "/tmp/tmux-1000/default,1234,0" },
+		v = { shell_error = 0 },
+		log = { levels = { WARN = 2, ERROR = 4, INFO = 1 } },
+		notify = function(msg, level)
+			table.insert(notify_calls, { msg = msg, level = level })
+		end,
+		trim = function(s)
+			return (s or ""):gsub("^%s+", ""):gsub("%s+$", "")
+		end,
+	}
+
+	package.loaded["orgmode"] = {
+		files = {
+			get_closest_headline = function()
+				if not has_heading then
+					return nil
+				end
+				return {
+					get_property = function(_, name)
+						return heading_props[name]
+					end,
+				}
+			end,
+		},
+	}
+end
+
+local function load_actions()
+	package.loaded["plugins.orgmode.actions"] = nil
+	return dofile(actions_dir .. "actions.lua")
+end
+
+local function find_system_call(prefix)
+	for _, call in ipairs(system_calls) do
+		if type(call) == "table" and call[1] == prefix[1] then
+			local match = true
+			for i, v in ipairs(prefix) do
+				if call[i] ~= v then
+					match = false
+					break
+				end
+			end
+			if match then
+				return call
+			end
+		end
+	end
+	return nil
+end
+
+describe("plugins.orgmode.actions", function()
+	local saved_vim, saved_orgmode
+
+	setup(function()
+		saved_vim = _G.vim
+		saved_orgmode = package.loaded["orgmode"]
+	end)
+
+	teardown(function()
+		_G.vim = saved_vim
+		package.loaded["orgmode"] = saved_orgmode
+	end)
+
+	before_each(function()
+		setup_vim_mock()
+	end)
+
+	describe("open_nvim_pane", function()
+		it("warns and returns when no heading is found", function()
+			has_heading = false
+			load_actions().open_nvim_pane()
+			assert.equals(0, #system_calls)
+			assert.is_true(#notify_calls > 0)
+			assert.equals(_G.vim.log.levels.WARN, notify_calls[1].level)
+		end)
+
+		it("warns when the heading lacks a :DIR: property", function()
+			heading_props.DIR = nil
+			load_actions().open_nvim_pane()
+			assert.equals(0, #system_calls)
+			assert.is_true(#notify_calls > 0)
+			assert.equals(_G.vim.log.levels.WARN, notify_calls[1].level)
+		end)
+
+		it("errors when the resolved directory does not exist", function()
+			heading_props.DIR = "~/missing"
+			_G.vim.fn.isdirectory = function()
+				return 0
+			end
+			load_actions().open_nvim_pane()
+			assert.equals(0, #system_calls)
+			local has_error = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.ERROR then
+					has_error = true
+				end
+			end
+			assert.is_true(has_error)
+		end)
+
+		it("errors when tmux executable is missing", function()
+			heading_props.DIR = "~/dir"
+			executables.tmux = false
+			load_actions().open_nvim_pane()
+			-- close_other_panes shouldn't fire either
+			assert.is_nil(find_system_call({ "tmux", "split-window" }))
+			local has_error = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.ERROR then
+					has_error = true
+				end
+			end
+			assert.is_true(has_error)
+		end)
+
+		it("errors when not inside a tmux session", function()
+			heading_props.DIR = "~/dir"
+			_G.vim.env.TMUX = nil
+			load_actions().open_nvim_pane()
+			assert.is_nil(find_system_call({ "tmux", "split-window" }))
+		end)
+
+		it("opens a tmux split with nvim and notifies on success", function()
+			heading_props.DIR = "~/dir"
+			load_actions().open_nvim_pane()
+			local call = find_system_call({ "tmux", "split-window" })
+			assert.is_not_nil(call)
+			assert.equals("nvim", call[#call])
+			-- INFO notification on success
+			local has_info = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.INFO then
+					has_info = true
+				end
+			end
+			assert.is_true(has_info)
+		end)
+
+		it("notifies on shell error from tmux split", function()
+			heading_props.DIR = "~/dir"
+			_G.vim.fn.system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[2] == "split-window" then
+					_G.vim.v.shell_error = 1
+				end
+				return ""
+			end
+			load_actions().open_nvim_pane()
+			local has_error = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.ERROR then
+					has_error = true
+				end
+			end
+			assert.is_true(has_error)
+		end)
+	end)
+
+	describe("resume_claude_session", function()
+		it("warns when :SESSION_ID: is missing", function()
+			heading_props.DIR = "~/dir"
+			heading_props.SESSION_ID = nil
+			load_actions().resume_claude_session()
+			assert.is_nil(find_system_call({ "tmux", "split-window" }))
+			local has_warn = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.WARN then
+					has_warn = true
+				end
+			end
+			assert.is_true(has_warn)
+		end)
+
+		it("errors when claude executable is missing", function()
+			heading_props.DIR = "~/dir"
+			heading_props.SESSION_ID = "abc-123"
+			executables.claude = false
+			load_actions().resume_claude_session()
+			assert.is_nil(find_system_call({ "tmux", "split-window" }))
+		end)
+
+		it("opens claude --resume in the right pane on success", function()
+			heading_props.DIR = "~/dir"
+			heading_props.SESSION_ID = "abc-123"
+			load_actions().resume_claude_session()
+			local call = find_system_call({ "tmux", "split-window" })
+			assert.is_not_nil(call)
+			-- last three args should be the claude command + flag + session id
+			assert.equals("abc-123", call[#call])
+			assert.equals("--resume", call[#call - 1])
+			assert.equals("claude", call[#call - 2])
+		end)
+	end)
+
+	describe("send_prompt_to_claude", function()
+		it("requires tmux to be available", function()
+			executables.tmux = false
+			load_actions().send_prompt_to_claude()
+			assert.is_nil(find_system_call({ "tmux", "send-keys" }))
+		end)
+
+		it("warns when there is no visual selection (zero marks)", function()
+			marks["<"] = { 0, 0 }
+			marks[">"] = { 0, 0 }
+			load_actions().send_prompt_to_claude()
+			assert.is_nil(find_system_call({ "tmux", "send-keys" }))
+			local has_warn = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.WARN then
+					has_warn = true
+				end
+			end
+			assert.is_true(has_warn)
+		end)
+
+		it("warns when the selected text is empty", function()
+			_G.vim.api.nvim_buf_get_text = function()
+				return { "" }
+			end
+			load_actions().send_prompt_to_claude()
+			assert.is_nil(find_system_call({ "tmux", "send-keys" }))
+		end)
+
+		it("sends the selection text to the right tmux pane", function()
+			load_actions().send_prompt_to_claude()
+			local call = find_system_call({ "tmux", "send-keys" })
+			assert.is_not_nil(call)
+			-- target = {right}; payload = "hello"; suffix = "Enter"
+			assert.equals("{right}", call[3])
+			assert.equals("hello", call[4])
+			assert.equals("Enter", call[5])
+		end)
+
+		it("normalizes inverted marks (end before start) before extraction", function()
+			marks["<"] = { 5, 10 }
+			marks[">"] = { 1, 0 }
+			-- Just assert no crash and that a send-keys call happens.
+			load_actions().send_prompt_to_claude()
+			assert.is_not_nil(find_system_call({ "tmux", "send-keys" }))
+		end)
+
+		it("notifies on shell error from tmux send-keys", function()
+			_G.vim.fn.system = function(args)
+				table.insert(system_calls, args)
+				if type(args) == "table" and args[2] == "send-keys" then
+					_G.vim.v.shell_error = 1
+				end
+				return ""
+			end
+			load_actions().send_prompt_to_claude()
+			local has_error = false
+			for _, n in ipairs(notify_calls) do
+				if n.level == _G.vim.log.levels.ERROR then
+					has_error = true
+				end
+			end
+			assert.is_true(has_error)
+		end)
+	end)
+
+	describe("open_terminal_pane", function()
+		it("warns when :DIR: is missing", function()
+			heading_props.DIR = nil
+			load_actions().open_terminal_pane()
+			assert.is_nil(find_system_call({ "tmux", "split-window" }))
+		end)
+
+		it("opens a tmux split without a trailing command (terminal)", function()
+			heading_props.DIR = "~/dir"
+			load_actions().open_terminal_pane()
+			local call = find_system_call({ "tmux", "split-window" })
+			assert.is_not_nil(call)
+			-- Last arg should be the directory ("~/dir"), not "nvim"
+			assert.equals("~/dir", call[#call])
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports the documented public functions", function()
+			local actions = load_actions()
+			assert.is_function(actions.open_nvim_pane)
+			assert.is_function(actions.resume_claude_session)
+			assert.is_function(actions.send_prompt_to_claude)
+			assert.is_function(actions.open_terminal_pane)
+		end)
+	end)
+end)

--- a/config/nvim/plugins/orgmode/keymaps.lua
+++ b/config/nvim/plugins/orgmode/keymaps.lua
@@ -1,156 +1,23 @@
 local M = {}
 
---- Get a property value from the current org heading
-local function get_heading_property(name)
-	local orgmode = require("orgmode")
-	local closest = orgmode.files:get_closest_headline()
-	if not closest then
-		return nil
-	end
-	return closest:get_property(name)
-end
-
---- Resolve :DIR: property to an expanded path, returns nil on failure
-local function resolve_dir()
-	local dir = get_heading_property("DIR")
-	if not dir or vim.trim(dir) == "" then
-		vim.notify("No :DIR: property found in current heading", vim.log.levels.WARN)
-		return nil
-	end
-	local expanded = vim.fn.expand(dir)
-	if vim.fn.isdirectory(expanded) == 0 then
-		vim.notify("Directory does not exist: " .. expanded, vim.log.levels.ERROR)
-		return nil
-	end
-	return expanded
-end
-
---- Validate tmux availability; returns true if usable
-local function check_tmux()
-	if vim.fn.executable("tmux") ~= 1 then
-		vim.notify("tmux is not installed", vim.log.levels.ERROR)
-		return false
-	end
-	if not vim.env.TMUX then
-		vim.notify("Not inside a tmux session", vim.log.levels.ERROR)
-		return false
-	end
-	return true
-end
-
---- Close all panes except the current one (keep max 2 panes)
-local function close_other_panes()
-	local count = tonumber(vim.fn.system("tmux list-panes | wc -l"))
-	if count and count >= 2 then
-		vim.fn.system({ "tmux", "kill-pane", "-a" })
-	end
-end
-
---- Open a tmux split pane with the given command args
-local function open_tmux_pane(split_args, success_msg, error_msg)
-	if not check_tmux() then
-		return
-	end
-	close_other_panes()
-	vim.fn.system(split_args)
-	if vim.v.shell_error ~= 0 then
-		vim.notify(error_msg, vim.log.levels.ERROR)
-		return
-	end
-	vim.notify(success_msg, vim.log.levels.INFO)
-end
-
---- Open nvim in left tmux pane at :DIR:
-local function open_nvim_pane()
-	local dir = resolve_dir()
-	if not dir then
-		return
-	end
-	open_tmux_pane(
-		{ "tmux", "split-window", "-hb", "-c", dir, "nvim" },
-		"Opened nvim in left pane: " .. dir,
-		"Failed to open tmux pane at: " .. dir
-	)
-end
-
---- Resume Claude session in right tmux pane from :SESSION_ID:
-local function resume_claude_session()
-	local dir = resolve_dir()
-	if not dir then
-		return
-	end
-	local session_id = get_heading_property("SESSION_ID")
-	if not session_id or vim.trim(session_id) == "" then
-		vim.notify("No :SESSION_ID: property found in current heading", vim.log.levels.WARN)
-		return
-	end
-	if vim.fn.executable("claude") ~= 1 then
-		vim.notify("claude is not installed", vim.log.levels.ERROR)
-		return
-	end
-	open_tmux_pane(
-		{ "tmux", "split-window", "-h", "-c", dir, "claude", "--resume", session_id },
-		"Resumed Claude session in right pane: " .. session_id,
-		"Failed to resume Claude session: " .. session_id
-	)
-end
-
---- Send visual selection to Claude Code in right tmux pane
-local function send_prompt_to_claude()
-	if not check_tmux() then
-		return
-	end
-	local srow, scol = unpack(vim.api.nvim_buf_get_mark(0, "<"))
-	local erow, ecol = unpack(vim.api.nvim_buf_get_mark(0, ">"))
-	if srow == 0 or erow == 0 then
-		vim.notify("No text selected", vim.log.levels.WARN)
-		return
-	end
-	if (srow > erow) or (srow == erow and scol > ecol) then
-		srow, erow = erow, srow
-		scol, ecol = ecol, scol
-	end
-	local lines = vim.api.nvim_buf_get_text(0, srow - 1, scol, erow - 1, ecol + 1, {})
-	local text = table.concat(lines, "\n")
-	if not text or text == "" then
-		vim.notify("No text selected", vim.log.levels.WARN)
-		return
-	end
-	vim.fn.system({ "tmux", "send-keys", "-t", "{right}", text, "Enter" })
-	if vim.v.shell_error ~= 0 then
-		vim.notify("Failed to send prompt to right pane", vim.log.levels.ERROR)
-		return
-	end
-	vim.notify("Sent prompt to Claude Code", vim.log.levels.INFO)
-end
-
---- Open terminal in left tmux pane at :DIR:
-local function open_terminal_pane()
-	local dir = resolve_dir()
-	if not dir then
-		return
-	end
-	open_tmux_pane(
-		{ "tmux", "split-window", "-hb", "-c", dir },
-		"Opened terminal in left pane: " .. dir,
-		"Failed to open terminal at: " .. dir
-	)
-end
+local ORG_DIR = "~/ghq/github.com/mikinovation/org"
 
 function M.setup()
-	local org_dir = "~/ghq/github.com/mikinovation/org"
-	vim.keymap.set("n", "<leader>or", "<cmd>edit " .. org_dir .. "/refile.org<CR>", { desc = "Open refile.org" })
+	local actions = require("plugins.orgmode.actions")
+	local map = vim.keymap.set
+
+	map("n", "<leader>or", "<cmd>edit " .. ORG_DIR .. "/refile.org<CR>", { desc = "Open refile.org" })
 
 	vim.api.nvim_create_autocmd("FileType", {
 		pattern = "org",
 		callback = function(ev)
-			local opts = function(desc)
+			local function bopts(desc)
 				return { buffer = ev.buf, desc = desc }
 			end
-			vim.keymap.set("n", "<leader>ov", open_nvim_pane, opts("Open nvim in left tmux pane at :DIR:"))
-			vim.keymap.set("n", "<leader>oC", resume_claude_session, opts("Resume Claude session in right tmux pane"))
-			vim.keymap.set("v", "<leader>op", send_prompt_to_claude, opts("Send selection to Claude Code"))
-			vim.keymap.set("n", "<leader>oT", open_terminal_pane, opts("Open terminal in left tmux pane at :DIR:"))
+			map("n", "<leader>ov", actions.open_nvim_pane, bopts("Open nvim in left tmux pane at :DIR:"))
+			map("n", "<leader>oC", actions.resume_claude_session, bopts("Resume Claude session in right tmux pane"))
+			map("v", "<leader>op", actions.send_prompt_to_claude, bopts("Send selection to Claude Code"))
+			map("n", "<leader>oT", actions.open_terminal_pane, bopts("Open terminal in left tmux pane at :DIR:"))
 		end,
 	})
 end

--- a/config/nvim/plugins/telescope/actions.lua
+++ b/config/nvim/plugins/telescope/actions.lua
@@ -61,7 +61,10 @@ function M.search_and_replace()
 				if confirmation:lower() == "y" then
 					local escaped_search = vim.fn.escape(search_term, "/\\")
 					local escaped_replace = vim.fn.escape(replace_term, "/\\&")
-					vim.cmd("%s/" .. escaped_search .. "/" .. escaped_replace .. "/g")
+					-- \V (very nomagic) makes the pattern literal: only the delimiter
+					-- and backslash remain special, so characters like . * [ ] ^ $
+					-- in the user's input match themselves.
+					vim.cmd("%s/\\V" .. escaped_search .. "/" .. escaped_replace .. "/g")
 					require("telescope.actions").close(prompt_bufnr)
 				end
 			end)

--- a/config/nvim/plugins/telescope/actions.lua
+++ b/config/nvim/plugins/telescope/actions.lua
@@ -1,0 +1,160 @@
+-- plugins/telescope/actions.lua
+-- Custom telescope-related action functions invoked by keymaps.
+
+local M = {}
+
+--- Find files within the current project, preferring git-tracked files.
+function M.project_files()
+	local opts = {}
+	local ok = pcall(require("telescope.builtin").git_files, opts)
+	if not ok then
+		require("telescope.builtin").find_files(opts)
+	end
+end
+
+--- Grep for the word under the cursor.
+function M.grep_current_word()
+	local word = vim.fn.expand("<cword>")
+	require("telescope.builtin").grep_string({ search = word })
+end
+
+--- Read the current visual selection as a single concatenated string.
+local function get_visual_selection()
+	local s_start = vim.fn.getpos("'<")
+	local s_end = vim.fn.getpos("'>")
+	local n_lines = math.abs(s_end[2] - s_start[2]) + 1
+	local lines = vim.api.nvim_buf_get_lines(0, s_start[2] - 1, s_end[2], false)
+	lines[1] = string.sub(lines[1], s_start[3], -1)
+	if n_lines == 1 then
+		lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3] - s_start[3] + 1)
+	else
+		lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3])
+	end
+	return table.concat(lines, " ")
+end
+
+--- Grep for the text currently selected in visual mode.
+function M.grep_visual_selection()
+	local text = get_visual_selection()
+	require("telescope.builtin").grep_string({ search = text })
+end
+
+--- Interactive search-and-replace flow backed by telescope grep.
+function M.search_and_replace()
+	local word = vim.fn.expand("<cword>")
+	local search_term = vim.fn.input("Search term: ", word)
+	if search_term == "" then
+		return
+	end
+
+	local replace_term = vim.fn.input("Replace with: ")
+	if replace_term == "" then
+		return
+	end
+
+	require("telescope.builtin").grep_string({
+		search = search_term,
+		prompt_title = "Search: " .. search_term .. " → Replace: " .. replace_term,
+		attach_mappings = function(_, map)
+			map("i", "<CR>", function(prompt_bufnr)
+				local confirmation = vim.fn.input("Execute? (y/n): ")
+				if confirmation:lower() == "y" then
+					local escaped_search = vim.fn.escape(search_term, "/\\")
+					local escaped_replace = vim.fn.escape(replace_term, "/\\&")
+					vim.cmd("%s/" .. escaped_search .. "/" .. escaped_replace .. "/g")
+					require("telescope.actions").close(prompt_bufnr)
+				end
+			end)
+			return true
+		end,
+	})
+end
+
+--- Strip noise from the contents of the unnamed yank register.
+local function get_normalized_yank()
+	local yanked = vim.fn.getreg('"')
+	return yanked:gsub("[\n\r]+", " "):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+--- Grep for the contents of the unnamed yank register.
+function M.grep_yanked_text()
+	local yanked = get_normalized_yank()
+	if yanked == "" then
+		vim.notify("No text in yank register", vim.log.levels.WARN)
+		return
+	end
+	require("telescope.builtin").grep_string({ search = yanked })
+end
+
+--- Find files using the unnamed yank register as the initial search query.
+function M.find_files_yanked()
+	local yanked = get_normalized_yank()
+	require("telescope.builtin").find_files({ default_text = yanked })
+end
+
+--- Find files relative to the current buffer's directory.
+function M.find_files_cwd()
+	local current_file = vim.fn.expand("%:p")
+	if current_file == "" then
+		vim.notify("No current buffer", vim.log.levels.WARN)
+		return
+	end
+	local cwd = vim.fn.fnamemodify(current_file, ":h")
+	local cwd_display = vim.fn.fnamemodify(cwd, ":~")
+	require("telescope.builtin").find_files({
+		cwd = cwd,
+		prompt_title = "Find Files (CWD: " .. cwd_display .. ")",
+	})
+end
+
+--- Live grep relative to the current buffer's directory.
+function M.live_grep_cwd()
+	local current_file = vim.fn.expand("%:p")
+	if current_file == "" then
+		vim.notify("No current buffer", vim.log.levels.WARN)
+		return
+	end
+	local cwd = vim.fn.fnamemodify(current_file, ":h")
+	local cwd_display = vim.fn.fnamemodify(cwd, ":~")
+	require("telescope.builtin").live_grep({
+		cwd = cwd,
+		prompt_title = "Live Grep (CWD: " .. cwd_display .. ")",
+	})
+end
+
+--- Fuzzy-find within the current buffer using a dropdown layout.
+function M.current_buffer_fuzzy_find()
+	require("telescope.builtin").current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
+		winblend = 10,
+		previewer = false,
+	}))
+end
+
+--- Live grep across all currently open buffers.
+function M.live_grep_open_files()
+	require("telescope.builtin").live_grep({
+		grep_open_files = true,
+		prompt_title = "Live Grep in Open Files",
+	})
+end
+
+--- Find files inside the user's Neovim config directory.
+function M.find_neovim_files()
+	require("telescope.builtin").find_files({ cwd = vim.fn.stdpath("config") })
+end
+
+--- Open the file_browser extension at the user's home directory.
+function M.file_browser_home()
+	require("telescope").extensions.file_browser.file_browser({
+		path = "~",
+		cwd = "~",
+		respect_gitignore = false,
+		hidden = true,
+		grouped = true,
+		previewer = false,
+		initial_mode = "normal",
+		layout_config = { height = 40 },
+	})
+end
+
+return M

--- a/config/nvim/plugins/telescope/actions_spec.lua
+++ b/config/nvim/plugins/telescope/actions_spec.lua
@@ -1,0 +1,359 @@
+-- luacheck: globals describe it before_each setup teardown assert
+
+local function spec_dir()
+	local info = debug.getinfo(1, "S")
+	local file = info.source:gsub("^@", "")
+	if not file:match("^/") then
+		local handle = io.popen("pwd")
+		if handle then
+			file = handle:read("*l") .. "/" .. file
+			handle:close()
+		end
+	end
+	return file:match("(.*/)")
+end
+
+local actions_dir = spec_dir()
+
+local builtin_calls
+local theme_calls
+local notify_calls
+local cmd_calls
+local input_queue
+local extension_calls
+local fail_git_files
+
+local function record(target, name)
+	return function(...)
+		table.insert(target, { name = name, args = { ... } })
+	end
+end
+
+local function setup_vim_mock()
+	builtin_calls = {}
+	theme_calls = {}
+	notify_calls = {}
+	cmd_calls = {}
+	input_queue = {}
+	extension_calls = {}
+	fail_git_files = false
+
+	local function noop_input()
+		if #input_queue == 0 then
+			return ""
+		end
+		return table.remove(input_queue, 1)
+	end
+
+	_G.vim = {
+		fn = {
+			expand = function(arg)
+				if arg == "<cword>" then
+					return "needle"
+				end
+				if arg == "%:p" then
+					return _G.vim._current_file or ""
+				end
+				return arg
+			end,
+			fnamemodify = function(path, modifier)
+				if modifier == ":h" then
+					return path:match("(.*)/[^/]+$") or path
+				elseif modifier == ":~" then
+					return path:gsub("^/home/[^/]+", "~")
+				end
+				return path
+			end,
+			getpos = function(mark)
+				if mark == "'<" then
+					return { 0, 1, 1, 0 }
+				end
+				return { 0, 1, 5, 0 }
+			end,
+			getreg = function()
+				return _G.vim._yank or ""
+			end,
+			input = function(prompt, default)
+				return noop_input(prompt, default)
+			end,
+			escape = function(s, _)
+				return s
+			end,
+			stdpath = function(what)
+				if what == "config" then
+					return "/etc/nvim"
+				end
+				return "/tmp"
+			end,
+		},
+		api = {
+			nvim_buf_get_lines = function()
+				return { "hello world" }
+			end,
+		},
+		keymap = { set = function() end },
+		log = { levels = { WARN = 2, ERROR = 4, INFO = 1 } },
+		notify = function(msg, level)
+			table.insert(notify_calls, { msg = msg, level = level })
+		end,
+		cmd = function(c)
+			table.insert(cmd_calls, c)
+		end,
+	}
+
+	package.loaded["telescope"] = {
+		extensions = {
+			file_browser = {
+				file_browser = function(opts)
+					table.insert(extension_calls, { name = "file_browser.file_browser", opts = opts })
+				end,
+			},
+		},
+	}
+
+	package.loaded["telescope.builtin"] = {
+		git_files = function(opts)
+			if fail_git_files then
+				error("not a git repo")
+			end
+			table.insert(builtin_calls, { name = "git_files", opts = opts })
+		end,
+		find_files = record(builtin_calls, "find_files"),
+		grep_string = record(builtin_calls, "grep_string"),
+		live_grep = record(builtin_calls, "live_grep"),
+		current_buffer_fuzzy_find = record(builtin_calls, "current_buffer_fuzzy_find"),
+	}
+
+	package.loaded["telescope.themes"] = {
+		get_dropdown = function(opts)
+			table.insert(theme_calls, { name = "get_dropdown", opts = opts })
+			return { dropdown = true, opts = opts }
+		end,
+	}
+
+	package.loaded["telescope.actions"] = {
+		close = function() end,
+	}
+end
+
+local function load_actions()
+	package.loaded["plugins.telescope.actions"] = nil
+	return dofile(actions_dir .. "actions.lua")
+end
+
+describe("plugins.telescope.actions", function()
+	local saved_vim, saved_loaded
+
+	setup(function()
+		saved_vim = _G.vim
+		saved_loaded = {
+			telescope = package.loaded["telescope"],
+			builtin = package.loaded["telescope.builtin"],
+			themes = package.loaded["telescope.themes"],
+			actions = package.loaded["telescope.actions"],
+		}
+	end)
+
+	teardown(function()
+		_G.vim = saved_vim
+		package.loaded["telescope"] = saved_loaded.telescope
+		package.loaded["telescope.builtin"] = saved_loaded.builtin
+		package.loaded["telescope.themes"] = saved_loaded.themes
+		package.loaded["telescope.actions"] = saved_loaded.actions
+	end)
+
+	before_each(function()
+		setup_vim_mock()
+	end)
+
+	describe("project_files", function()
+		it("uses git_files when the buffer is in a git repo", function()
+			fail_git_files = false
+			load_actions().project_files()
+			assert.equals(1, #builtin_calls)
+			assert.equals("git_files", builtin_calls[1].name)
+		end)
+
+		it("falls back to find_files when git_files errors", function()
+			fail_git_files = true
+			load_actions().project_files()
+			assert.equals(1, #builtin_calls)
+			assert.equals("find_files", builtin_calls[1].name)
+		end)
+	end)
+
+	describe("grep_current_word", function()
+		it("greps the word under the cursor", function()
+			load_actions().grep_current_word()
+			assert.equals(1, #builtin_calls)
+			assert.equals("grep_string", builtin_calls[1].name)
+			assert.equals("needle", builtin_calls[1].args[1].search)
+		end)
+	end)
+
+	describe("grep_visual_selection", function()
+		it("greps the joined visual selection text", function()
+			load_actions().grep_visual_selection()
+			assert.equals(1, #builtin_calls)
+			assert.equals("grep_string", builtin_calls[1].name)
+			assert.is_string(builtin_calls[1].args[1].search)
+		end)
+	end)
+
+	describe("search_and_replace", function()
+		it("returns early when the search term is empty", function()
+			input_queue = { "", "" }
+			load_actions().search_and_replace()
+			assert.equals(0, #builtin_calls)
+		end)
+
+		it("returns early when the replace term is empty", function()
+			input_queue = { "foo", "" }
+			load_actions().search_and_replace()
+			assert.equals(0, #builtin_calls)
+		end)
+
+		it("invokes grep_string with both terms reflected in the prompt title", function()
+			input_queue = { "foo", "bar" }
+			load_actions().search_and_replace()
+			assert.equals(1, #builtin_calls)
+			local call = builtin_calls[1]
+			assert.equals("grep_string", call.name)
+			assert.equals("foo", call.args[1].search)
+			assert.truthy(call.args[1].prompt_title:find("foo"))
+			assert.truthy(call.args[1].prompt_title:find("bar"))
+			assert.is_function(call.args[1].attach_mappings)
+		end)
+	end)
+
+	describe("grep_yanked_text", function()
+		it("notifies and returns when the yank register is empty", function()
+			_G.vim._yank = ""
+			load_actions().grep_yanked_text()
+			assert.equals(0, #builtin_calls)
+			assert.equals(1, #notify_calls)
+			assert.equals(_G.vim.log.levels.WARN, notify_calls[1].level)
+		end)
+
+		it("greps for the normalized yank contents", function()
+			_G.vim._yank = "  some\n\nyanked\rtext  "
+			load_actions().grep_yanked_text()
+			assert.equals(1, #builtin_calls)
+			assert.equals("grep_string", builtin_calls[1].name)
+			-- Newlines/CRs collapse to spaces; leading/trailing whitespace stripped.
+			assert.is_nil(builtin_calls[1].args[1].search:find("[\n\r]"))
+			assert.equals("some", builtin_calls[1].args[1].search:match("^%S+"))
+		end)
+	end)
+
+	describe("find_files_yanked", function()
+		it("uses normalized yank content as the default text", function()
+			_G.vim._yank = "  hello\nworld  "
+			load_actions().find_files_yanked()
+			assert.equals(1, #builtin_calls)
+			assert.equals("find_files", builtin_calls[1].name)
+			assert.equals("hello world", builtin_calls[1].args[1].default_text)
+		end)
+	end)
+
+	describe("find_files_cwd", function()
+		it("notifies when there is no current buffer", function()
+			_G.vim._current_file = ""
+			load_actions().find_files_cwd()
+			assert.equals(0, #builtin_calls)
+			assert.equals(1, #notify_calls)
+		end)
+
+		it("uses the current buffer's directory", function()
+			_G.vim._current_file = "/home/u/proj/src/main.lua"
+			load_actions().find_files_cwd()
+			assert.equals(1, #builtin_calls)
+			assert.equals("find_files", builtin_calls[1].name)
+			assert.equals("/home/u/proj/src", builtin_calls[1].args[1].cwd)
+			assert.truthy(builtin_calls[1].args[1].prompt_title:find("CWD"))
+		end)
+	end)
+
+	describe("live_grep_cwd", function()
+		it("notifies when there is no current buffer", function()
+			_G.vim._current_file = ""
+			load_actions().live_grep_cwd()
+			assert.equals(0, #builtin_calls)
+			assert.equals(1, #notify_calls)
+		end)
+
+		it("uses the current buffer's directory", function()
+			_G.vim._current_file = "/home/u/proj/src/main.lua"
+			load_actions().live_grep_cwd()
+			assert.equals(1, #builtin_calls)
+			assert.equals("live_grep", builtin_calls[1].name)
+			assert.equals("/home/u/proj/src", builtin_calls[1].args[1].cwd)
+		end)
+	end)
+
+	describe("current_buffer_fuzzy_find", function()
+		it("uses the dropdown theme with previewer disabled", function()
+			load_actions().current_buffer_fuzzy_find()
+			assert.equals(1, #builtin_calls)
+			assert.equals("current_buffer_fuzzy_find", builtin_calls[1].name)
+			assert.equals(1, #theme_calls)
+			assert.equals(false, theme_calls[1].opts.previewer)
+			assert.equals(10, theme_calls[1].opts.winblend)
+		end)
+	end)
+
+	describe("live_grep_open_files", function()
+		it("limits live_grep to the open buffers", function()
+			load_actions().live_grep_open_files()
+			assert.equals(1, #builtin_calls)
+			assert.equals("live_grep", builtin_calls[1].name)
+			assert.is_true(builtin_calls[1].args[1].grep_open_files)
+		end)
+	end)
+
+	describe("find_neovim_files", function()
+		it("uses stdpath('config') as the cwd", function()
+			load_actions().find_neovim_files()
+			assert.equals(1, #builtin_calls)
+			assert.equals("find_files", builtin_calls[1].name)
+			assert.equals("/etc/nvim", builtin_calls[1].args[1].cwd)
+		end)
+	end)
+
+	describe("file_browser_home", function()
+		it("opens the file_browser extension at the home directory", function()
+			load_actions().file_browser_home()
+			assert.equals(1, #extension_calls)
+			local call = extension_calls[1]
+			assert.equals("file_browser.file_browser", call.name)
+			assert.equals("~", call.opts.path)
+			assert.equals("~", call.opts.cwd)
+			assert.is_true(call.opts.hidden)
+			assert.is_false(call.opts.respect_gitignore)
+			assert.equals("normal", call.opts.initial_mode)
+		end)
+	end)
+
+	describe("module shape", function()
+		it("exports the documented public functions", function()
+			local actions = load_actions()
+			local expected = {
+				"project_files",
+				"grep_current_word",
+				"grep_visual_selection",
+				"search_and_replace",
+				"grep_yanked_text",
+				"find_files_yanked",
+				"find_files_cwd",
+				"live_grep_cwd",
+				"current_buffer_fuzzy_find",
+				"live_grep_open_files",
+				"find_neovim_files",
+				"file_browser_home",
+			}
+			for _, name in ipairs(expected) do
+				assert.is_function(actions[name], name .. " should be exported")
+			end
+		end)
+	end)
+end)

--- a/config/nvim/plugins/telescope/actions_spec.lua
+++ b/config/nvim/plugins/telescope/actions_spec.lua
@@ -224,6 +224,48 @@ describe("plugins.telescope.actions", function()
 			assert.truthy(call.args[1].prompt_title:find("bar"))
 			assert.is_function(call.args[1].attach_mappings)
 		end)
+
+		it("builds a very-nomagic substitute command when the user confirms", function()
+			-- Inputs: search term, replace term, then the Execute? prompt.
+			input_queue = { "foo.bar", "baz", "y" }
+			load_actions().search_and_replace()
+
+			-- Capture the <CR> callback registered inside attach_mappings.
+			local attach = builtin_calls[1].args[1].attach_mappings
+			local captured_cb
+			local function fake_map(_, key, cb)
+				if key == "<CR>" then
+					captured_cb = cb
+				end
+			end
+			attach(nil, fake_map)
+			assert.is_function(captured_cb)
+			captured_cb(42)
+
+			assert.equals(1, #cmd_calls)
+			-- The command must start with "%s/\V" so . is matched literally.
+			assert.truthy(cmd_calls[1]:find("^%%s/\\V"), "expected \\V prefix, got: " .. cmd_calls[1])
+			assert.truthy(cmd_calls[1]:find("foo%.bar"))
+			assert.truthy(cmd_calls[1]:find("baz"))
+			assert.truthy(cmd_calls[1]:match("/g$"))
+		end)
+
+		it("does not execute substitute when the user declines confirmation", function()
+			input_queue = { "foo", "bar", "n" }
+			load_actions().search_and_replace()
+
+			local attach = builtin_calls[1].args[1].attach_mappings
+			local captured_cb
+			local function fake_map(_, key, cb)
+				if key == "<CR>" then
+					captured_cb = cb
+				end
+			end
+			attach(nil, fake_map)
+			captured_cb(42)
+
+			assert.equals(0, #cmd_calls)
+		end)
 	end)
 
 	describe("grep_yanked_text", function()

--- a/config/nvim/plugins/telescope/keymaps.lua
+++ b/config/nvim/plugins/telescope/keymaps.lua
@@ -1,184 +1,43 @@
 local M = {}
 
--- Custom function to search within project (respects .gitignore)
-local function project_files()
-	local opts = {}
-	local ok = pcall(require("telescope.builtin").git_files, opts)
-	if not ok then
-		require("telescope.builtin").find_files(opts)
-	end
-end
-
--- Grep search for word under cursor
-local function grep_current_word()
-	local word = vim.fn.expand("<cword>")
-	require("telescope.builtin").grep_string({ search = word })
-end
-
--- Search for text selected in visual mode
-local function grep_visual_selection()
-	local function get_visual_selection()
-		local s_start = vim.fn.getpos("'<")
-		local s_end = vim.fn.getpos("'>")
-		local n_lines = math.abs(s_end[2] - s_start[2]) + 1
-		local lines = vim.api.nvim_buf_get_lines(0, s_start[2] - 1, s_end[2], false)
-		lines[1] = string.sub(lines[1], s_start[3], -1)
-		if n_lines == 1 then
-			lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3] - s_start[3] + 1)
-		else
-			lines[n_lines] = string.sub(lines[n_lines], 1, s_end[3])
-		end
-		return table.concat(lines, " ")
-	end
-
-	local text = get_visual_selection()
-	require("telescope.builtin").grep_string({ search = text })
-end
-
--- Search and replace in files
-local function search_and_replace()
-	local word = vim.fn.expand("<cword>")
-	local search_term = vim.fn.input("Search term: ", word)
-	if search_term == "" then
-		return
-	end
-
-	local replace_term = vim.fn.input("Replace with: ")
-	if replace_term == "" then
-		return
-	end
-
-	-- Display matching locations using Telescope
-	require("telescope.builtin").grep_string({
-		search = search_term,
-		prompt_title = "Search: " .. search_term .. " → Replace: " .. replace_term,
-		attach_mappings = function(_, map)
-			map("i", "<CR>", function(prompt_bufnr)
-				local confirmation = vim.fn.input("Execute? (y/n): ")
-				if confirmation:lower() == "y" then
-					local escaped_search = vim.fn.escape(search_term, "/\\")
-					local escaped_replace = vim.fn.escape(replace_term, "/\\&")
-					vim.cmd("%s/" .. escaped_search .. "/" .. escaped_replace .. "/g")
-					require("telescope.actions").close(prompt_bufnr)
-				end
-			end)
-			return true
-		end,
-	})
-end
-
--- Search for yanked text (from default register)
-local function grep_yanked_text()
-	local yanked = vim.fn.getreg('"')
-	-- Remove newlines and extra whitespace for cleaner search
-	yanked = yanked:gsub("[\n\r]+", " "):gsub("^%s+", ""):gsub("%s+$", "")
-	if yanked == "" then
-		vim.notify("No text in yank register", vim.log.levels.WARN)
-		return
-	end
-	require("telescope.builtin").grep_string({ search = yanked })
-end
-
--- Find files with yanked text as initial search
-local function find_files_yanked()
-	local yanked = vim.fn.getreg('"')
-	yanked = yanked:gsub("[\n\r]+", " "):gsub("^%s+", ""):gsub("%s+$", "")
-	require("telescope.builtin").find_files({ default_text = yanked })
-end
-
--- Find files relative to current buffer's directory
-local function find_files_cwd()
-	local current_file = vim.fn.expand("%:p")
-	if current_file == "" then
-		vim.notify("No current buffer", vim.log.levels.WARN)
-		return
-	end
-	local cwd = vim.fn.fnamemodify(current_file, ":h")
-	local cwd_display = vim.fn.fnamemodify(cwd, ":~")
-	require("telescope.builtin").find_files({
-		cwd = cwd,
-		prompt_title = "Find Files (CWD: " .. cwd_display .. ")",
-	})
-end
-
--- Live grep relative to current buffer's directory
-local function live_grep_cwd()
-	local current_file = vim.fn.expand("%:p")
-	if current_file == "" then
-		vim.notify("No current buffer", vim.log.levels.WARN)
-		return
-	end
-	local cwd = vim.fn.fnamemodify(current_file, ":h")
-	local cwd_display = vim.fn.fnamemodify(cwd, ":~")
-	require("telescope.builtin").live_grep({
-		cwd = cwd,
-		prompt_title = "Live Grep (CWD: " .. cwd_display .. ")",
-	})
-end
-
 function M.setup()
-	-- Basic Telescope keymappings
 	local builtin = require("telescope.builtin")
-	vim.keymap.set("n", "<leader>ff", builtin.find_files, { desc = "[F]ind [F]iles" })
-	vim.keymap.set("n", "<leader>fw", builtin.grep_string, { desc = "[F]ind Current [W]ord" })
-	vim.keymap.set("n", "<leader>fg", builtin.live_grep, { desc = "[F]ind by [G]rep" })
-	vim.keymap.set("n", "<leader>fr", builtin.resume, { desc = "[F]ind [R]esume" })
-	vim.keymap.set("n", "<leader>f.", builtin.oldfiles, { desc = '[F]ind Recent Files ("." for repeat)' })
-	vim.keymap.set("n", "<leader>fB", builtin.buffers, { desc = "[F]ind [B]uffers" })
+	local actions = require("plugins.telescope.actions")
+	local map = vim.keymap.set
+
+	-- Basic Telescope keymappings
+	map("n", "<leader>ff", builtin.find_files, { desc = "[F]ind [F]iles" })
+	map("n", "<leader>fw", builtin.grep_string, { desc = "[F]ind Current [W]ord" })
+	map("n", "<leader>fg", builtin.live_grep, { desc = "[F]ind by [G]rep" })
+	map("n", "<leader>fr", builtin.resume, { desc = "[F]ind [R]esume" })
+	map("n", "<leader>f.", builtin.oldfiles, { desc = '[F]ind Recent Files ("." for repeat)' })
+	map("n", "<leader>fB", builtin.buffers, { desc = "[F]ind [B]uffers" })
 
 	-- Additional Telescope keymappings
-	vim.keymap.set("n", "<leader>f/", function()
-		builtin.current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
-			winblend = 10,
-			previewer = false,
-		}))
-	end, { desc = "[F]ind [/] Fuzzily in Current Buffer" })
-
-	vim.keymap.set("n", "<leader>s/", function()
-		builtin.live_grep({
-			grep_open_files = true,
-			prompt_title = "Live Grep in Open Files",
-		})
-	end, { desc = "[S]earch [/] in Open Files" })
-
-	vim.keymap.set("n", "<leader>fn", function()
-		builtin.find_files({ cwd = vim.fn.stdpath("config") })
-	end, { desc = "[F]ind [N]eovim Files" })
+	map("n", "<leader>f/", actions.current_buffer_fuzzy_find, { desc = "[F]ind [/] Fuzzily in Current Buffer" })
+	map("n", "<leader>s/", actions.live_grep_open_files, { desc = "[S]earch [/] in Open Files" })
+	map("n", "<leader>fn", actions.find_neovim_files, { desc = "[F]ind [N]eovim Files" })
 
 	-- Extension keymappings
-	vim.keymap.set("n", "<leader>fb", ":Telescope file_browser<CR>", { desc = "[F]ile [B]rowser" })
-
-	-- Open home directory in file_browser
-	vim.keymap.set("n", "<leader>fH", function()
-		require("telescope").extensions.file_browser.file_browser({
-			path = "~",
-			cwd = "~",
-			respect_gitignore = false,
-			hidden = true,
-			grouped = true,
-			previewer = false,
-			initial_mode = "normal",
-			layout_config = { height = 40 },
-		})
-	end, { desc = "[F]ile Browser - [H]ome Directory" })
-
-	vim.keymap.set("n", "<leader>fM", ":Telescope media_files<CR>", { desc = "[F]ind [M]edia Files" })
-	vim.keymap.set("n", "<leader>sf", ":Telescope frecency<CR>", { desc = "[S]earch [F]requent Files" })
+	map("n", "<leader>fb", ":Telescope file_browser<CR>", { desc = "[F]ile [B]rowser" })
+	map("n", "<leader>fH", actions.file_browser_home, { desc = "[F]ile Browser - [H]ome Directory" })
+	map("n", "<leader>fM", ":Telescope media_files<CR>", { desc = "[F]ind [M]edia Files" })
+	map("n", "<leader>sf", ":Telescope frecency<CR>", { desc = "[S]earch [F]requent Files" })
 
 	-- Git integration (git status/blame/branch covered by vim-fugitive)
-	vim.keymap.set("n", "<leader>gC", builtin.git_commits, { desc = "[G]it [C]ommits (Telescope)" })
+	map("n", "<leader>gC", builtin.git_commits, { desc = "[G]it [C]ommits (Telescope)" })
 
 	-- Custom function keymappings
-	vim.keymap.set("n", "<leader>fp", project_files, { desc = "[F]ind [P]roject Files" })
-	vim.keymap.set("n", "<leader>sw", grep_current_word, { desc = "[S]earch Current [W]ord" })
-	vim.keymap.set("v", "<leader>sw", grep_visual_selection, { desc = "[S]earch Selected [W]ord" })
-	vim.keymap.set("n", "<leader>sr", search_and_replace, { desc = "[S]earch and [R]eplace" })
-	vim.keymap.set("n", "<leader>fyg", grep_yanked_text, { desc = "[F]ind [Y]anked Text (Grep)" })
-	vim.keymap.set("n", "<leader>fyf", find_files_yanked, { desc = "[F]ind [Y]anked Text (Files)" })
+	map("n", "<leader>fp", actions.project_files, { desc = "[F]ind [P]roject Files" })
+	map("n", "<leader>sw", actions.grep_current_word, { desc = "[S]earch Current [W]ord" })
+	map("v", "<leader>sw", actions.grep_visual_selection, { desc = "[S]earch Selected [W]ord" })
+	map("n", "<leader>sr", actions.search_and_replace, { desc = "[S]earch and [R]eplace" })
+	map("n", "<leader>fyg", actions.grep_yanked_text, { desc = "[F]ind [Y]anked Text (Grep)" })
+	map("n", "<leader>fyf", actions.find_files_yanked, { desc = "[F]ind [Y]anked Text (Files)" })
 
 	-- Current buffer directory search keymappings
-	vim.keymap.set("n", "<leader>fcf", find_files_cwd, { desc = "[F]ind Files in [C]urrent Directory" })
-	vim.keymap.set("n", "<leader>fcg", live_grep_cwd, { desc = "[F]ind by [G]rep in [C]urrent Directory" })
+	map("n", "<leader>fcf", actions.find_files_cwd, { desc = "[F]ind Files in [C]urrent Directory" })
+	map("n", "<leader>fcg", actions.live_grep_cwd, { desc = "[F]ind by [G]rep in [C]urrent Directory" })
 end
 
 return M


### PR DESCRIPTION
### 📚 Description

This PR refactors the codebase to separate concerns between keymaps and action logic by extracting all non-trivial functions from keymap files into dedicated `actions.lua` modules. This improves code organization, testability, and maintainability.

#### Changes Made

**New Action Modules:**
- `config/nvim/actions.lua` - Global actions (format_document, open_in_explorer, toggle_lazydocker)
- `config/nvim/lsp/actions.lua` - LSP-specific actions (format_document)
- `config/nvim/plugins/telescope/actions.lua` - Telescope actions (project_files, grep_current_word, search_and_replace, etc.)
- `config/nvim/plugins/orgmode/actions.lua` - Orgmode actions (open_nvim_pane, resume_claude_session, send_prompt_to_claude, etc.)
- `config/nvim/plugins/neotest/actions.lua` - Neotest actions (run_nearest, debug_nearest, run_file)
- `config/nvim/plugins/gitlinker/actions.lua` - Gitlinker actions (copy_git_link)

**Updated Keymap Files:**
All keymap files now import and delegate to their corresponding action modules, keeping them focused solely on key bindings:
- `config/nvim/keymaps.lua`
- `config/nvim/lsp/keymaps.lua`
- `config/nvim/plugins/telescope/keymaps.lua`
- `config/nvim/plugins/orgmode/keymaps.lua`
- `config/nvim/plugins/neotest/keymaps.lua`
- `config/nvim/plugins/gitlinker/keymaps.lua`

**Comprehensive Test Coverage:**
Added full test suites for all action modules:
- `config/nvim/actions_spec.lua` - Tests for global actions
- `config/nvim/lsp/actions_spec.lua` - Tests for LSP actions
- `config/nvim/plugins/telescope/actions_spec.lua` - Tests for telescope actions (359 lines, 11 test cases)
- `config/nvim/plugins/orgmode/actions_spec.lua` - Tests for orgmode actions (346 lines, 13 test cases)
- `config/nvim/plugins/neotest/actions_spec.lua` - Tests for neotest actions
- `config/nvim/plugins/gitlinker/actions_spec.lua` - Tests for gitlinker actions

#### Benefits

1. **Separation of Concerns** - Keymaps are now purely declarative, containing only key bindings
2. **Improved Testability** - Action logic can be unit tested independently without mocking keymaps
3. **Better Code Organization** - Related functionality is grouped logically
4. **Easier Maintenance** - Changes to action logic don't require touching keymap files
5. **Reusability** - Actions can be invoked from multiple contexts (keymaps, commands, etc.)

#### Test Plan

All new action modules include comprehensive unit tests with mocked dependencies. The test suites verify:
- Correct function behavior under normal conditions
- Proper error handling and notifications
- Integration with external dependencies (telescope, orgmode, neotest, etc.)
- Edge cases and boundary conditions

Run tests with: `busted config/nvim/**/*_spec.lua`

https://claude.ai/code/session_01PZfWGDjTy27uUkuEZaJ8ZR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Keybinding handlers moved to centralized action modules; shortcuts and behavior remain unchanged.

* **New Features**
  * Formatting, open-in-Explorer, and Lazydocker toggle wired to actions.
  * Neotest run/debug/file, Gitlinker copy-link, Orgmode tmux helpers, and Telescope helpers (project files, visual grep, search-and-replace, file browser, and related searches) exposed via mapped keys.

* **Tests**
  * Added specs validating the new action behaviors and error/success notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->