### PR TITLE
Add password-store integration for secrets management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 result
 .env
+.env.*
+!.env.example
 node_modules
+
+# Secrets - never commit these to this public repository
+.password-store/
+*.gpg
+*.asc
+.envrc
+.envrc.local
 
 # Claude directory - ignore everything except commands
 /claude/*

--- a/README.md
+++ b/README.md
@@ -93,6 +93,61 @@ cd ~/ghq/github.com/mikinovation/dotfiles
 ./setup.sh
 ```
 
+## Secrets management (password-store)
+
+シークレットや環境ごとの変数は `password-store` (`pass`) で管理します。
+暗号化されたストア本体 (`~/.password-store`) は **この public dotfiles には含めず**、
+別のプライベートリポジトリとして管理してください。
+
+### 初期セットアップ
+
+```bash
+# 1. GPG 鍵を作成（既にあればスキップ）
+gpg --full-generate-key
+
+# 2. password-store を初期化
+pass init <YOUR_GPG_KEY_ID>
+
+# 3. 既存のストアを private リポジトリから復元する場合
+git clone git@github.com:<you>/password-store.git ~/.password-store
+```
+
+### ディレクトリ規約
+
+環境切替用の変数は `env/<env-name>/<VAR_NAME>` に格納します。
+
+```
+~/.password-store/
+├── env/
+│   ├── dev/
+│   │   ├── AWS_ACCESS_KEY_ID.gpg
+│   │   └── DATABASE_URL.gpg
+│   └── prod/
+│       └── ...
+```
+
+投入例:
+
+```bash
+pass insert env/dev/AWS_ACCESS_KEY_ID
+pass insert -m env/dev/DATABASE_URL
+```
+
+### 環境の切り替え
+
+zsh に `passenv` / `passrun` / `passenv-unset` が定義されます。
+
+```bash
+# カレントシェルに env/dev/* を export
+passenv dev
+
+# サブシェルだけに env/prod/* を注入して 1 コマンド実行（推奨）
+passrun prod aws s3 ls
+
+# passenv でロードした変数をクリア
+passenv-unset
+```
+
 ## lint and format
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -115,31 +115,39 @@ git clone git@github.com:<you>/password-store.git ~/.password-store
 ### ディレクトリ規約
 
 グローバル用と案件別の 2 階層を併存運用します。
+環境名は **`local` / `dev` / `staging` / `prod` をそれぞれ独立した環境として扱います**
+（`local` は自分の手元マシン、`dev` は共有の開発環境、という別物の位置付け）。
+デフォルトは `local`（=自分のマシン）です。
 
 ```
 ~/.password-store/
 ├── env/                      # グローバル（案件に紐づかない共通環境変数）
-│   ├── dev/
-│   │   ├── AWS_ACCESS_KEY_ID.gpg
-│   │   └── DATABASE_URL.gpg
+│   ├── local/                # 自分のマシン用（Docker, モック DB 等）
+│   ├── dev/                  # 共有の開発環境
+│   ├── staging/
 │   └── prod/
 ├── project-a/                # 案件別（<project> は git repo の basename 推奨）
+│   ├── local/
+│   │   ├── API_KEY.gpg
+│   │   └── DATABASE_URL.gpg
 │   ├── dev/
 │   │   ├── API_KEY.gpg
 │   │   └── DATABASE_URL.gpg
 │   ├── staging/
 │   └── prod/
 └── project-b/
-    └── dev/
+    └── local/
 ```
 
 投入例:
 
 ```bash
-# グローバル
-pass insert env/dev/AWS_ACCESS_KEY_ID
+# グローバル（環境ごとに独立）
+pass insert env/local/DATABASE_URL
+pass insert env/dev/DATABASE_URL
 
-# 案件別
+# 案件別（local と dev は別物の値）
+pass insert project-a/local/API_KEY
 pass insert project-a/dev/API_KEY
 pass insert -m project-a/prod/DATABASE_URL
 ```
@@ -149,11 +157,13 @@ pass insert -m project-a/prod/DATABASE_URL
 zsh に以下が定義されます。
 
 ```bash
-# グローバル env/dev/* をカレントシェルに export
-passenv dev
+# グローバル（local と dev は別物、それぞれロード可能）
+passenv local                 # env/local/*
+passenv dev                   # env/dev/*
 
-# 案件別 project-a/prod/* をカレントシェルに export
-passenv project-a prod
+# 案件別
+passenv project-a local       # project-a/local/*
+passenv project-a dev         # project-a/dev/*
 passenv project-a/prod        # スラッシュ形でも可
 
 # サブシェルだけに注入して 1 コマンド実行（推奨）
@@ -171,7 +181,7 @@ passenv-unset
 
 ```sh
 # ~/ghq/github.com/mikinovation/project-a/.envrc
-use pass                      # project = git repo 名、env = $APP_ENV か dev
+use pass                      # project = git repo 名、env = $APP_ENV か local
 ```
 
 初回のみ許可:
@@ -180,12 +190,14 @@ use pass                      # project = git repo 名、env = $APP_ENV か dev
 direnv allow .
 ```
 
-dev/prod の切替は `projenv` で:
+環境の切替は `projenv` で（local / dev / staging / prod はそれぞれ別環境）:
 
 ```bash
-cd ~/ghq/.../project-a        # APP_ENV=dev が自動ロード
-projenv prod                  # direnv reload で prod に切替
-projenv dev                   # dev に戻す
+cd ~/ghq/.../project-a        # APP_ENV=local が自動ロード（自分のマシン）
+projenv dev                   # direnv reload で共有開発環境に切替
+projenv staging               # ステージング
+projenv prod                  # 本番
+projenv                       # 引数省略で local (自マシン) に戻る
 projenv-reset                 # APP_ENV を unset してデフォルト挙動に
 ```
 
@@ -194,8 +206,8 @@ projenv-reset                 # APP_ENV を unset してデフォルト挙動に
 ### プロンプト表示
 
 Powerlevel10k の右プロンプトに `<project>:<env>` が表示されます
-（prod は赤、staging は黄、dev は緑）。どの案件のどの環境で作業しているかが
-常に視認できるので、prod への誤操作を防げます。
+（prod は赤、staging は黄、dev は緑、local はシアン）。どの案件のどの環境で
+作業しているかが常に視認できるので、prod への誤操作を防げます。
 
 ## lint and format
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ git clone git@github.com:<you>/password-store.git ~/.password-store
 （`local` は自分の手元マシン、`dev` は共有の開発環境、という別物の位置付け）。
 デフォルトは `local`（=自分のマシン）です。
 
+**ロードポリシー**: カレントシェルや direnv で**常駐できるのは `local` のみ**です。
+`dev` / `staging` / `prod` は **`passrun` による単発（サブシェル）実行専用**で、
+誤って prod の認証情報が対話シェルに残り続ける事故を避ける設計にしています。
+
 ```
 ~/.password-store/
 ├── env/                      # グローバル（案件に紐づかない共通環境変数）
@@ -152,36 +156,55 @@ pass insert project-a/dev/API_KEY
 pass insert -m project-a/prod/DATABASE_URL
 ```
 
-### シェル関数による切り替え
+### シェル関数（`local` 常駐）
 
-zsh に以下が定義されます。
+`passenv` はカレントシェルへロードしますが、**`local` 以外は拒否**されます。
+非 local 環境を使いたい場合は `passrun`（サブシェル）を使ってください。
 
 ```bash
-# グローバル（local と dev は別物、それぞれロード可能）
+# OK: local はカレントシェルに常駐可能
 passenv local                 # env/local/*
-passenv dev                   # env/dev/*
-
-# 案件別
 passenv project-a local       # project-a/local/*
-passenv project-a dev         # project-a/dev/*
-passenv project-a/prod        # スラッシュ形でも可
+passenv project-a/local       # スラッシュ形
 
-# サブシェルだけに注入して 1 コマンド実行（推奨）
-passrun env/prod aws s3 ls
-passrun project-a prod npm run start
+# NG: dev/staging/prod は passenv で拒否される
+passenv dev
+# => passenv: 'dev' is restricted to single-command execution.
+#             Only 'local' can be loaded into the current shell.
+#             Run instead:  passrun env/dev <command>
 
 # クリア
 passenv-unset
 ```
 
-### direnv による案件ごとの自動切替
+### 単発実行（`dev` / `staging` / `prod` 専用）
 
-案件 (`<project>/<env>`) は direnv と組み合わせると `cd` だけで自動ロードされます。
-各プロジェクトの `.envrc` は 1 行で済みます。
+非 local 環境は `passrun` で**サブシェル内の単発コマンドとしてのみ**実行します。
+コマンド終了と同時に認証情報は破棄され、対話シェルには残りません。
+
+```bash
+# グローバル dev/prod の単発実行
+passrun env/dev  aws s3 ls
+passrun env/prod aws s3 ls
+
+# 案件別
+passrun project-a dev     npm run start
+passrun project-a staging npm run deploy
+passrun project-a prod    aws s3 ls
+
+# 対話的に作業したい場合はシェルそのものを単発で起動
+passrun project-a prod zsh
+# => prod の値が入った一時シェル。exit すると元のシェルに戻る。
+#    プロンプトは赤色の <project>:prod 表示で誤操作防止。
+```
+
+### direnv による自動ロード（`local` のみ）
+
+各プロジェクト repo の `.envrc` に 1 行書けば、`cd` で自動的に `local` がロードされます。
 
 ```sh
 # ~/ghq/github.com/mikinovation/project-a/.envrc
-use pass                      # project = git repo 名、env = $APP_ENV か local
+use pass                      # project = git repo 名、env = local
 ```
 
 初回のみ許可:
@@ -190,18 +213,9 @@ use pass                      # project = git repo 名、env = $APP_ENV か loca
 direnv allow .
 ```
 
-環境の切替は `projenv` で（local / dev / staging / prod はそれぞれ別環境）:
-
-```bash
-cd ~/ghq/.../project-a        # APP_ENV=local が自動ロード（自分のマシン）
-projenv dev                   # direnv reload で共有開発環境に切替
-projenv staging               # ステージング
-projenv prod                  # 本番
-projenv                       # 引数省略で local (自マシン) に戻る
-projenv-reset                 # APP_ENV を unset してデフォルト挙動に
-```
-
-`.envrc` を `use pass project-a prod` のように引数で固定化することもできます。
+direnv が読み込めるのも **`local` のみ**です。`.envrc` 側で `use pass project-a prod`
+のように非 local を指定した場合はロード拒否され、エラーメッセージに `passrun` の
+使い方が案内されます。
 
 ### プロンプト表示
 

--- a/README.md
+++ b/README.md
@@ -114,39 +114,88 @@ git clone git@github.com:<you>/password-store.git ~/.password-store
 
 ### ディレクトリ規約
 
-環境切替用の変数は `env/<env-name>/<VAR_NAME>` に格納します。
+グローバル用と案件別の 2 階層を併存運用します。
 
 ```
 ~/.password-store/
-├── env/
+├── env/                      # グローバル（案件に紐づかない共通環境変数）
 │   ├── dev/
 │   │   ├── AWS_ACCESS_KEY_ID.gpg
 │   │   └── DATABASE_URL.gpg
 │   └── prod/
-│       └── ...
+├── project-a/                # 案件別（<project> は git repo の basename 推奨）
+│   ├── dev/
+│   │   ├── API_KEY.gpg
+│   │   └── DATABASE_URL.gpg
+│   ├── staging/
+│   └── prod/
+└── project-b/
+    └── dev/
 ```
 
 投入例:
 
 ```bash
+# グローバル
 pass insert env/dev/AWS_ACCESS_KEY_ID
-pass insert -m env/dev/DATABASE_URL
+
+# 案件別
+pass insert project-a/dev/API_KEY
+pass insert -m project-a/prod/DATABASE_URL
 ```
 
-### 環境の切り替え
+### シェル関数による切り替え
 
-zsh に `passenv` / `passrun` / `passenv-unset` が定義されます。
+zsh に以下が定義されます。
 
 ```bash
-# カレントシェルに env/dev/* を export
+# グローバル env/dev/* をカレントシェルに export
 passenv dev
 
-# サブシェルだけに env/prod/* を注入して 1 コマンド実行（推奨）
-passrun prod aws s3 ls
+# 案件別 project-a/prod/* をカレントシェルに export
+passenv project-a prod
+passenv project-a/prod        # スラッシュ形でも可
 
-# passenv でロードした変数をクリア
+# サブシェルだけに注入して 1 コマンド実行（推奨）
+passrun env/prod aws s3 ls
+passrun project-a prod npm run start
+
+# クリア
 passenv-unset
 ```
+
+### direnv による案件ごとの自動切替
+
+案件 (`<project>/<env>`) は direnv と組み合わせると `cd` だけで自動ロードされます。
+各プロジェクトの `.envrc` は 1 行で済みます。
+
+```sh
+# ~/ghq/github.com/mikinovation/project-a/.envrc
+use pass                      # project = git repo 名、env = $APP_ENV か dev
+```
+
+初回のみ許可:
+
+```bash
+direnv allow .
+```
+
+dev/prod の切替は `projenv` で:
+
+```bash
+cd ~/ghq/.../project-a        # APP_ENV=dev が自動ロード
+projenv prod                  # direnv reload で prod に切替
+projenv dev                   # dev に戻す
+projenv-reset                 # APP_ENV を unset してデフォルト挙動に
+```
+
+`.envrc` を `use pass project-a prod` のように引数で固定化することもできます。
+
+### プロンプト表示
+
+Powerlevel10k の右プロンプトに `<project>:<env>` が表示されます
+（prod は赤、staging は黄、dev は緑）。どの案件のどの環境で作業しているかが
+常に視認できるので、prod への誤操作を防げます。
 
 ## lint and format
 

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -58,6 +58,7 @@
     ./programs/agent-skills
     ./programs/tmux
     ./programs/aws
+    ./programs/pass
   ];
 
   # Home Manager can also manage your environment variables through

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -59,6 +59,7 @@
     ./programs/tmux
     ./programs/aws
     ./programs/pass
+    ./programs/direnv
   ];
 
   # Home Manager can also manage your environment variables through

--- a/config/nix/programs/direnv/default.nix
+++ b/config/nix/programs/direnv/default.nix
@@ -9,7 +9,7 @@
   #   ~/.password-store/<project>/<env>/<VAR_NAME>
   #
   # where <project> defaults to the current git repository's basename
-  # and <env> defaults to $APP_ENV (or "dev" if unset). This lets each
+  # and <env> defaults to $APP_ENV (or "local" if unset). This lets each
   # repository's `.envrc` be a single line:
   #
   #   use pass
@@ -24,7 +24,7 @@
     stdlib = ''
       use_pass() {
         local project="''${1:-}"
-        local env="''${2:-''${APP_ENV:-dev}}"
+        local env="''${2:-''${APP_ENV:-local}}"
 
         if [[ -z "$project" ]]; then
           local toplevel

--- a/config/nix/programs/direnv/default.nix
+++ b/config/nix/programs/direnv/default.nix
@@ -1,0 +1,67 @@
+{ ... }:
+
+{
+  # direnv + nix-direnv for per-project environment management.
+  #
+  # The custom `use_pass` stdlib function loads GPG-encrypted secrets
+  # from password-store under:
+  #
+  #   ~/.password-store/<project>/<env>/<VAR_NAME>
+  #
+  # where <project> defaults to the current git repository's basename
+  # and <env> defaults to $APP_ENV (or "dev" if unset). This lets each
+  # repository's `.envrc` be a single line:
+  #
+  #   use pass
+  #
+  # and individual envs are switched via the `projenv <env>` shell
+  # function (defined in the zsh module), which re-triggers direnv.
+  programs.direnv = {
+    enable = true;
+    enableZshIntegration = true;
+    nix-direnv.enable = true;
+
+    stdlib = ''
+      use_pass() {
+        local project="''${1:-}"
+        local env="''${2:-''${APP_ENV:-dev}}"
+
+        if [[ -z "$project" ]]; then
+          local toplevel
+          toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || {
+            log_error "use_pass: project not given and not inside a git repository"
+            return 1
+          }
+          project=$(basename "$toplevel")
+        fi
+
+        local prefix="$project/$env"
+        if ! pass ls "$prefix" >/dev/null 2>&1; then
+          log_error "use_pass: no pass entries under $prefix"
+          return 1
+        fi
+
+        local keys
+        keys=$(pass ls "$prefix" 2>/dev/null \
+          | tail -n +2 \
+          | sed 's/^[├└│─ ]*//' \
+          | grep -v '^$')
+
+        if [[ -z "$keys" ]]; then
+          log_error "use_pass: empty prefix $prefix"
+          return 1
+        fi
+
+        local key val
+        while IFS= read -r key; do
+          val=$(pass show "$prefix/$key" | head -n1)
+          export "$key=$val"
+          watch_file "$HOME/.password-store/$prefix/$key.gpg"
+        done <<< "$keys"
+
+        export APP_PROJECT="$project"
+        export APP_ENV="$env"
+      }
+    '';
+  };
+}

--- a/config/nix/programs/direnv/default.nix
+++ b/config/nix/programs/direnv/default.nix
@@ -14,8 +14,10 @@
   #
   #   use pass
   #
-  # and individual envs are switched via the `projenv <env>` shell
-  # function (defined in the zsh module), which re-triggers direnv.
+  # POLICY: only the 'local' env is ever loaded persistently. Non-local
+  # envs (dev / staging / prod / ...) must go through `passrun` (defined
+  # in the zsh module) for one-shot subshell execution, so that a prod
+  # credential never lingers in an interactive shell by accident.
   programs.direnv = {
     enable = true;
     enableZshIntegration = true;
@@ -25,6 +27,12 @@
       use_pass() {
         local project="''${1:-}"
         local env="''${2:-''${APP_ENV:-local}}"
+
+        if [[ "$env" != "local" ]]; then
+          log_error "use_pass: only 'local' may be loaded persistently via direnv."
+          log_error "         Use: passrun ''${project:-<project>} $env <command>"
+          return 1
+        fi
 
         if [[ -z "$project" ]]; then
           local toplevel

--- a/config/nix/programs/pass/default.nix
+++ b/config/nix/programs/pass/default.nix
@@ -1,0 +1,33 @@
+{ pkgs, ... }:
+
+{
+  # password-store (pass) for managing secrets as GPG-encrypted files.
+  #
+  # The encrypted store itself (~/.password-store) is NOT tracked in this
+  # public dotfiles repository; it is expected to be a separate PRIVATE
+  # repository cloned at runtime. This module only provides the tooling
+  # and shell integration.
+  programs.password-store = {
+    enable = true;
+    package = pkgs.pass.withExtensions (exts: [
+      exts.pass-otp
+      exts.pass-import
+    ]);
+    settings = {
+      PASSWORD_STORE_DIR = "$HOME/.password-store";
+      PASSWORD_STORE_GENERATED_LENGTH = "32";
+    };
+  };
+
+  # GPG is the encryption backend for pass.
+  programs.gpg.enable = true;
+
+  # gpg-agent caches passphrases so pass does not re-prompt on every call.
+  services.gpg-agent = {
+    enable = true;
+    enableZshIntegration = true;
+    pinentry.package = pkgs.pinentry-curses;
+    defaultCacheTtl = 3600;
+    maxCacheTtl = 28800;
+  };
+}

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -68,26 +68,62 @@
       # bun completions
       [ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"
 
-      # pass (password-store) environment variable helpers.
-      # Secrets live in ~/.password-store and are expected to be kept in
-      # a separate private repository; nothing from the store is committed
-      # to this public dotfiles repo.
+      # ----------------------------------------------------------------
+      # password-store based environment variable helpers.
+      #
+      # Two hierarchies are supported in parallel:
+      #   ~/.password-store/env/<env>/<KEY>           # global
+      #   ~/.password-store/<project>/<env>/<KEY>     # project-scoped
+      # where <project> conventionally matches the git repo basename.
+      #
+      # The store itself lives in a separate PRIVATE repository; nothing
+      # from it is committed to this public dotfiles repo.
+      # ----------------------------------------------------------------
+
+      # Internal: list leaf entry names under a pass prefix.
+      _passenv_list_keys() {
+        pass ls "$1" 2>/dev/null \
+          | tail -n +2 \
+          | sed 's/^[├└│─ ]*//' \
+          | grep -v '^$'
+      }
+
+      # Internal: resolve args into a pass prefix.
+      #   one arg without '/'  -> env/<arg>   (global shorthand)
+      #   one arg with '/'     -> the arg itself (explicit path)
+      #   two args             -> <project>/<env>
+      _passenv_prefix() {
+        case $# in
+          1)
+            if [[ "$1" == */* ]]; then
+              printf '%s\n' "$1"
+            else
+              printf 'env/%s\n' "$1"
+            fi
+            ;;
+          2) printf '%s/%s\n' "$1" "$2" ;;
+          *) return 2 ;;
+        esac
+      }
+
       passenv() {
-        local env="''${1:-dev}"
-        local prefix="env/$env"
+        local prefix
+        if ! prefix=$(_passenv_prefix "$@"); then
+          echo "usage: passenv <env>                  # global env/<env>/*" >&2
+          echo "       passenv <project> <env>        # <project>/<env>/*" >&2
+          echo "       passenv <project>/<env>        # explicit path" >&2
+          return 2
+        fi
+
         if ! pass ls "$prefix" >/dev/null 2>&1; then
           echo "passenv: no entries under $prefix" >&2
           return 1
         fi
 
         local keys
-        keys=$(pass ls "$prefix" 2>/dev/null \
-          | tail -n +2 \
-          | sed 's/^[├└│─ ]*//' \
-          | grep -v '^$')
-
+        keys=$(_passenv_list_keys "$prefix")
         if [[ -z "$keys" ]]; then
-          echo "passenv: no entries under $prefix" >&2
+          echo "passenv: empty prefix $prefix" >&2
           return 1
         fi
 
@@ -99,32 +135,77 @@
           PASS_ENV_LOADED_KEYS="$PASS_ENV_LOADED_KEYS $key"
         done <<< "$keys"
 
-        export PASS_ENV="$env"
-        echo "passenv: loaded '$env' ($(echo "$keys" | wc -l) vars)"
+        if [[ "''${prefix%%/*}" == "env" ]]; then
+          export APP_PROJECT="global"
+          export APP_ENV="''${prefix#env/}"
+        else
+          export APP_PROJECT="''${prefix%%/*}"
+          export APP_ENV="''${prefix#*/}"
+        fi
+        echo "passenv: loaded '$prefix' ($(echo "$keys" | wc -l) vars)"
       }
 
       passenv-unset() {
-        if [[ -z "$PASS_ENV_LOADED_KEYS" ]]; then
-          return 0
-        fi
+        [[ -z "''${PASS_ENV_LOADED_KEYS:-}" ]] && return 0
         local key
         for key in $PASS_ENV_LOADED_KEYS; do
           unset "$key"
         done
-        unset PASS_ENV PASS_ENV_LOADED_KEYS
+        unset PASS_ENV_LOADED_KEYS APP_PROJECT APP_ENV
       }
 
       passrun() {
         if [[ $# -lt 2 ]]; then
-          echo "usage: passrun <env> <command> [args...]" >&2
+          echo "usage: passrun <prefix> <cmd...>          (prefix must contain /)" >&2
+          echo "       passrun <project> <env> <cmd...>" >&2
           return 2
         fi
-        local env="$1"; shift
+        local prefix
+        if [[ "$1" == */* ]]; then
+          prefix="$1"; shift
+        else
+          if [[ $# -lt 3 ]]; then
+            echo "passrun: need <project> <env> <cmd...> when first arg has no /" >&2
+            return 2
+          fi
+          prefix="$1/$2"; shift 2
+        fi
         (
-          passenv "$env" >/dev/null || exit 1
+          passenv "$prefix" >/dev/null || exit 1
           "$@"
         )
       }
+
+      # Switch APP_ENV in the current direnv-managed directory and reload.
+      projenv() {
+        if ! command -v direnv >/dev/null 2>&1; then
+          echo "projenv: direnv not found" >&2
+          return 1
+        fi
+        export APP_ENV="''${1:-dev}"
+        direnv reload
+      }
+
+      # Clear the manual APP_ENV override and let direnv re-evaluate.
+      projenv-reset() {
+        unset APP_ENV
+        command -v direnv >/dev/null 2>&1 && direnv reload
+      }
+
+      # Powerlevel10k segment: show <project>:<env> in the right prompt.
+      # Prod is red to discourage accidents; staging yellow, dev green.
+      function prompt_app_env() {
+        [[ -z "''${APP_ENV:-}" ]] && return
+        local color=blue
+        case "$APP_ENV" in
+          prod|production) color=red ;;
+          stg|staging)     color=yellow ;;
+          dev|development) color=green ;;
+        esac
+        p10k segment -f "$color" -t "''${APP_PROJECT:-?}:$APP_ENV"
+      }
+      typeset -ga POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS
+      POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS+=(app_env)
     '';
   };
 }

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -76,6 +76,12 @@
       #   ~/.password-store/<project>/<env>/<KEY>     # project-scoped
       # where <project> conventionally matches the git repo basename.
       #
+      # POLICY: only 'local' may be loaded into the current shell or kept
+      # persistent via direnv. Non-local envs (dev / staging / prod / ...)
+      # are intentionally restricted to one-shot subshell execution via
+      # `passrun` so that a prod credential never lingers in an
+      # interactive shell by accident.
+      #
       # The store itself lives in a separate PRIVATE repository; nothing
       # from it is committed to this public dotfiles repo.
       # ----------------------------------------------------------------
@@ -106,14 +112,19 @@
         esac
       }
 
-      passenv() {
-        local prefix
-        if ! prefix=$(_passenv_prefix "$@"); then
-          echo "usage: passenv <env>                  # global env/<env>/*" >&2
-          echo "       passenv <project> <env>        # <project>/<env>/*" >&2
-          echo "       passenv <project>/<env>        # explicit path" >&2
-          return 2
+      # Internal: extract the env component from a resolved prefix.
+      _passenv_env_of() {
+        if [[ "''${1%%/*}" == "env" ]]; then
+          printf '%s\n' "''${1#env/}"
+        else
+          printf '%s\n' "''${1#*/}"
         fi
+      }
+
+      # Internal: actually load pass entries under $prefix into the
+      # current environment. No policy check - callers must enforce.
+      _passenv_load() {
+        local prefix="$1"
 
         if ! pass ls "$prefix" >/dev/null 2>&1; then
           echo "passenv: no entries under $prefix" >&2
@@ -145,6 +156,27 @@
         echo "passenv: loaded '$prefix' ($(echo "$keys" | wc -l) vars)"
       }
 
+      passenv() {
+        local prefix
+        if ! prefix=$(_passenv_prefix "$@"); then
+          echo "usage: passenv <env>                  # global env/<env>/*" >&2
+          echo "       passenv <project> <env>        # <project>/<env>/*" >&2
+          echo "       passenv <project>/<env>        # explicit path" >&2
+          return 2
+        fi
+
+        local env_part
+        env_part=$(_passenv_env_of "$prefix")
+        if [[ "$env_part" != "local" ]]; then
+          echo "passenv: '$env_part' is restricted to single-command execution." >&2
+          echo "         Only 'local' can be loaded into the current shell." >&2
+          echo "         Run instead:  passrun $prefix <command>" >&2
+          return 1
+        fi
+
+        _passenv_load "$prefix"
+      }
+
       passenv-unset() {
         [[ -z "''${PASS_ENV_LOADED_KEYS:-}" ]] && return 0
         local key
@@ -171,30 +203,15 @@
           prefix="$1/$2"; shift 2
         fi
         (
-          passenv "$prefix" >/dev/null || exit 1
+          _passenv_load "$prefix" >/dev/null || exit 1
           "$@"
         )
       }
 
-      # Switch APP_ENV in the current direnv-managed directory and reload.
-      projenv() {
-        if ! command -v direnv >/dev/null 2>&1; then
-          echo "projenv: direnv not found" >&2
-          return 1
-        fi
-        export APP_ENV="''${1:-local}"
-        direnv reload
-      }
-
-      # Clear the manual APP_ENV override and let direnv re-evaluate.
-      projenv-reset() {
-        unset APP_ENV
-        command -v direnv >/dev/null 2>&1 && direnv reload
-      }
-
       # Powerlevel10k segment: show <project>:<env> in the right prompt.
       # Prod is red to discourage accidents; staging yellow, dev green,
-      # local cyan.
+      # local cyan. In the outer shell only 'local' is ever persistent,
+      # so a non-cyan segment means you are in a `passrun` subshell.
       function prompt_app_env() {
         [[ -z "''${APP_ENV:-}" ]] && return
         local color=blue

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -182,7 +182,7 @@
           echo "projenv: direnv not found" >&2
           return 1
         fi
-        export APP_ENV="''${1:-dev}"
+        export APP_ENV="''${1:-local}"
         direnv reload
       }
 
@@ -193,7 +193,8 @@
       }
 
       # Powerlevel10k segment: show <project>:<env> in the right prompt.
-      # Prod is red to discourage accidents; staging yellow, dev green.
+      # Prod is red to discourage accidents; staging yellow, dev green,
+      # local cyan.
       function prompt_app_env() {
         [[ -z "''${APP_ENV:-}" ]] && return
         local color=blue
@@ -201,6 +202,7 @@
           prod|production) color=red ;;
           stg|staging)     color=yellow ;;
           dev|development) color=green ;;
+          local)           color=cyan ;;
         esac
         p10k segment -f "$color" -t "''${APP_PROJECT:-?}:$APP_ENV"
       }

--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -67,6 +67,64 @@
 
       # bun completions
       [ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"
+
+      # pass (password-store) environment variable helpers.
+      # Secrets live in ~/.password-store and are expected to be kept in
+      # a separate private repository; nothing from the store is committed
+      # to this public dotfiles repo.
+      passenv() {
+        local env="''${1:-dev}"
+        local prefix="env/$env"
+        if ! pass ls "$prefix" >/dev/null 2>&1; then
+          echo "passenv: no entries under $prefix" >&2
+          return 1
+        fi
+
+        local keys
+        keys=$(pass ls "$prefix" 2>/dev/null \
+          | tail -n +2 \
+          | sed 's/^[├└│─ ]*//' \
+          | grep -v '^$')
+
+        if [[ -z "$keys" ]]; then
+          echo "passenv: no entries under $prefix" >&2
+          return 1
+        fi
+
+        export PASS_ENV_LOADED_KEYS=""
+        local key val
+        while IFS= read -r key; do
+          val=$(pass show "$prefix/$key" | head -n1)
+          export "$key=$val"
+          PASS_ENV_LOADED_KEYS="$PASS_ENV_LOADED_KEYS $key"
+        done <<< "$keys"
+
+        export PASS_ENV="$env"
+        echo "passenv: loaded '$env' ($(echo "$keys" | wc -l) vars)"
+      }
+
+      passenv-unset() {
+        if [[ -z "$PASS_ENV_LOADED_KEYS" ]]; then
+          return 0
+        fi
+        local key
+        for key in $PASS_ENV_LOADED_KEYS; do
+          unset "$key"
+        done
+        unset PASS_ENV PASS_ENV_LOADED_KEYS
+      }
+
+      passrun() {
+        if [[ $# -lt 2 ]]; then
+          echo "usage: passrun <env> <command> [args...]" >&2
+          return 2
+        fi
+        local env="$1"; shift
+        (
+          passenv "$env" >/dev/null || exit 1
+          "$@"
+        )
+      }
     '';
   };
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR adds comprehensive secrets management using `password-store` (`pass`), a GPG-encrypted password manager. The implementation includes:

**Changes:**

1. **New `config/nix/programs/pass/default.nix`** - Configures password-store with:
   - `pass` with OTP and import extensions
   - GPG as the encryption backend
   - `gpg-agent` for passphrase caching with 1-hour default TTL
   - Pinentry for secure passphrase entry

2. **Shell integration in `config/nix/programs/zsh/default.nix`** - Three new zsh functions:
   - `passenv <env>` - Loads environment variables from `env/<env>/*` entries into the current shell
   - `passenv-unset` - Clears previously loaded environment variables
   - `passrun <env> <command>` - Runs a command in a subshell with injected environment variables (recommended for isolation)

3. **Updated `.gitignore`** - Prevents accidental commits of:
   - `.password-store/` directory
   - GPG files (`*.gpg`, `*.asc`)
   - `.envrc` and `.envrc.local` files
   - `.env.*` files (except `.env.example`)

4. **Documentation in `README.md`** - Added "Secrets management (password-store)" section with:
   - Setup instructions (GPG key generation, pass initialization, repository cloning)
   - Directory structure conventions
   - Usage examples for all three shell functions

5. **Updated `config/nix/home.nix`** - Imports the new pass module

**Design notes:**
- The encrypted password store (`~/.password-store`) is intentionally NOT tracked in this public dotfiles repository
- Users maintain their own private repository for secrets
- Environment variables follow the `env/<env-name>/<VAR_NAME>` convention for easy organization
- `passrun` is recommended for production use to avoid polluting the current shell environment

https://claude.ai/code/session_01AHsWxrvxy6FKqSHgMfUxXH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated password-store (GPG-backed) into the environment with direnv and Zsh support, plus prompt display and commands to load/run with project-scoped secrets.
  * Enabled GPG agent/passphrase caching and related tooling integration for smoother secret access.

* **Documentation**
  * Added a detailed secrets management guide: setup, pass layout, direnv/zsh workflows, and examples.

* **Chores**
  * Expanded .gitignore to exclude environment and secret-related files and directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->