### PR TITLE
Set default model to Sonnet and enable bash working directory maintenance

### DIFF
--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -82,6 +82,7 @@
 
     # settings.json
     settings = {
+      model = "sonnet";
       includeCoAuthoredBy = false;
       teammateMode = "in-process";
       hooks = {
@@ -114,6 +115,7 @@
       };
       env = {
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+        CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
         DISABLE_AUTOUPDATER = "1";
       };
       permissions = {


### PR DESCRIPTION
## Summary
- Set default Claude Code model to Sonnet via `model = "sonnet"` in settings
- Add `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` env var to prevent bash commands from changing the working directory

## Test plan
- [x] Run `./setup.sh` to deploy home-manager config
- [x] Verify `~/.claude/settings.json` contains `"model": "sonnet"`
- [x] Verify `~/.claude/settings.json` contains `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` in env
- [x] Confirm Claude Code uses Sonnet as default model
- [x] Confirm bash commands maintain project working directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code configuration to use the Sonnet model and enable project directory behavior settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->