### PR TITLE
Set Claude Code effort level to high

### DIFF
--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -83,6 +83,7 @@
     # settings.json
     settings = {
       model = "sonnet";
+      effortLevel = "high";
       includeCoAuthoredBy = false;
       teammateMode = "in-process";
       hooks = {


### PR DESCRIPTION
## Summary
- Add `effortLevel = "high"` to Claude Code settings in Nix configuration

## Test plan
- [x] Run `home-manager switch` to apply the new settings
- [x] Verify `~/.claude/settings.json` contains `"effortLevel": "high"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code program configuration to set the effort level to high. This optimization enhances code analysis and generation quality by prioritizing comprehensive outputs when assisting with development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->