### PR TITLE
Remove tmux auto-start on WSL launch

### DIFF
--- a/config/nix/programs/zsh/default.nix
+++ b/config/nix/programs/zsh/default.nix
@@ -21,15 +21,6 @@
     '';
 
     initContent = ''
-      # Auto-start tmux on WSL launch
-      if grep -qi microsoft /proc/version 2>/dev/null \
-        && command -v tmux &> /dev/null \
-        && [ -z "$TMUX" ] && [ -z "$INSIDE_EMACS" ] && [ -z "$VSCODE_RESOLVING_ENVIRONMENT" ]; then
-        TMUX_START_DIR="$HOME/ghq/github.com/mikinovation/org"
-        [ -d "$TMUX_START_DIR" ] || TMUX_START_DIR="$HOME"
-        exec tmux new-session -A -s main -c "$TMUX_START_DIR"
-      fi
-
       # Enable Powerlevel10k instant prompt
       if [[ -r "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh" ]]; then
         source "''${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-''${(%):-%n}.zsh"


### PR DESCRIPTION
## Summary
- Remove the tmux auto-start block from zsh initContent that automatically launched tmux on WSL shell sessions

## Test plan
- [x] Open a new shell session on WSL and verify tmux does not start automatically
- [x] Verify zsh starts normally with Powerlevel10k and other plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic tmux session initialization on WSL shell startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->