### PR TITLE
Fix home-manager evaluation warnings

### DIFF
--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -103,9 +103,6 @@
     # Sheldon configuration
     ".config/sheldon/plugins.toml".source = ../sheldon/plugins.toml;
 
-    # WSL-specific configuration
-    "ghq/github.com/mikinovation/dotfiles/config/zsh/plugins/wsl.zsh".source = ../zsh/plugins/wsl.zsh;
-
   };
 
   xdg.configFile."nix/nix.conf".force = true;

--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -138,6 +138,6 @@
 
     # Agents, CLAUDE.md
     agentsDir = ../../../claude/agents;
-    memory.source = ../../../claude/CLAUDE.md;
+    context = ../../../claude/CLAUDE.md;
   };
 }

--- a/config/nix/programs/git/default.nix
+++ b/config/nix/programs/git/default.nix
@@ -4,8 +4,7 @@
   programs.git = {
     enable = true;
 
-    userName = "mikinovation";
-    userEmail = "maneuver2472@gmail.com";
+    signing.format = null;
 
     ignores = [
       # Custom tools
@@ -60,6 +59,10 @@
     ];
 
     settings = {
+      user = {
+        name = "mikinovation";
+        email = "maneuver2472@gmail.com";
+      };
       fetch = {
         prune = true;
         pruneTags = true;

--- a/config/nix/programs/neovim/default.nix
+++ b/config/nix/programs/neovim/default.nix
@@ -7,6 +7,8 @@
     viAlias = true;
     vimAlias = true;
     vimdiffAlias = true;
+    withRuby = false;
+    withPython3 = false;
 
     # Install additional packages that neovim plugins might need
     extraPackages = with pkgs; [


### PR DESCRIPTION
## Summary

- Remove redundant `wsl.zsh` entry from `home.file` (file already exists at that path as part of the dotfiles repo itself)
- Migrate `programs.git.userName`/`userEmail` to `programs.git.settings.user.name`/`email` (renamed option)
- Explicitly set `programs.git.signing.format = null` to silence default-changed warning
- Explicitly set `programs.neovim.withRuby = false` and `withPython3 = false` to silence default-changed warnings
- Migrate `programs.claude-code.memory.source` to `programs.claude-code.context` (renamed option)

## Test plan

- [x] Run `./setup.sh` and confirm no warnings except `Git tree is dirty` and the upstream `utillinux` warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Git configuration settings structure
  * Removed WSL-specific Zsh plugin support
  * Disabled Ruby and Python 3 language support in Neovim
  * Updated configuration field references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->