### PR TITLE
refactor: migrate skill config from agent-skills to claude-code and bump effort level

### DIFF
--- a/config/claude/skills/org-flow/create-issue/SKILL.md
+++ b/config/claude/skills/org-flow/create-issue/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: org-log
-description: 作業内容をorg-mode形式で記録するスキル。タスク完了時・セッション終了時・コミット後・PR作成後など、何らかの作業が一段落したタイミングで必ず使用する。ユーザーが「/org-log」「ログ書いて」「orgに記録」「作業まとめ」「refile」「作業ログ」と言った場合はもちろん、CLAUDE.mdで作業完了後の実行が指示されている場合も必ずこのスキルを使用すること。セッションログとrefile.orgインデックスの2箇所に書き込む。
+name: org-flow:create-issue
+description: 作業内容をorg-mode形式で記録するスキル。タスク完了時・セッション終了時・コミット後・PR作成後など、何らかの作業が一段落したタイミングで必ず使用する。ユーザーが「/create-issue」「/org-flow:create-issue」「ログ書いて」「orgに記録」「作業まとめ」「refile」「作業ログ」と言った場合はもちろん、CLAUDE.mdで作業完了後の実行が指示されている場合も必ずこのスキルを使用すること。セッションログとrefile.orgインデックスの2箇所に書き込む。
 ---
 
-# org-log: 作業ログをorg-modeに記録
+# org-flow:create-issue: 作業ログをorg-modeに記録
 
 セッションログを **ghqと同じディレクトリ構造** で記録し、`refile.org` にはリンク付きインデックスのみ追記する。
 

--- a/config/nix/programs/agent-skills/default.nix
+++ b/config/nix/programs/agent-skills/default.nix
@@ -32,7 +32,6 @@
       enable = [
         "find-skills"
         "skill-creator"
-        "team-dev"
         "vue-best-practices"
         "nuxt"
         "test-driven-development"

--- a/config/nix/programs/agent-skills/default.nix
+++ b/config/nix/programs/agent-skills/default.nix
@@ -30,9 +30,6 @@
         path = inputs.obra-superpowers;
         subdir = "skills";
       };
-      local = {
-        path = ../../../claude/skills;
-      };
     };
 
     skills = {
@@ -40,11 +37,9 @@
         "find-skills"
         "skill-creator"
         "agent-browser"
-        "team-dev"
         "vue-best-practices"
         "nuxt"
         "test-driven-development"
-        "org-flow/create-issue"
       ];
     };
 

--- a/config/nix/programs/claude-code/default.nix
+++ b/config/nix/programs/claude-code/default.nix
@@ -83,7 +83,7 @@
     # settings.json
     settings = {
       model = "sonnet";
-      effortLevel = "high";
+      effortLevel = "xhigh";
       includeCoAuthoredBy = false;
       teammateMode = "in-process";
       hooks = {
@@ -134,6 +134,12 @@
           "Bash(git fetch *)"
         ];
       };
+    };
+
+    # Skills
+    skills = {
+      "org-flow:create-issue" = ../../../claude/skills/org-flow/create-issue;
+      "team-dev" = ../../../claude/skills/team-dev;
     };
 
     # Agents, CLAUDE.md


### PR DESCRIPTION
## Summary

- Move `org-flow:create-issue` and `team-dev` skill registration from `agent-skills` module to `claude-code` module
- Remove local skills source from `agent-skills` config
- Increase `effortLevel` from `high` to `xhigh`

## Test plan

- [x] Verify skills are available in Claude Code after nix rebuild
- [x] Confirm `org-flow:create-issue` and `team-dev` skills load correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates
* Issue creation skill identifier has been updated for improved command recognition
* Claude Code analysis effort level increased to "xhigh" for more comprehensive and thorough responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->