### PR TITLE
chore: remove agent-browser skill from nix configuration

### DIFF
--- a/config/nix/flake.nix
+++ b/config/nix/flake.nix
@@ -24,10 +24,6 @@
       url = "github:anthropics/skills";
       flake = false;
     };
-    agent-browser = {
-      url = "github:vercel-labs/agent-browser";
-      flake = false;
-    };
     vercel-skills = {
       url = "github:vercel-labs/skills";
       flake = false;

--- a/config/nix/programs/agent-skills/default.nix
+++ b/config/nix/programs/agent-skills/default.nix
@@ -14,10 +14,6 @@
         path = inputs.anthropic-skills;
         subdir = "skills";
       };
-      agent-browser = {
-        path = inputs.agent-browser;
-        subdir = "skills";
-      };
       vercel-skills = {
         path = inputs.vercel-skills;
         subdir = "skills";
@@ -39,7 +35,6 @@
       enable = [
         "find-skills"
         "skill-creator"
-        "agent-browser"
         "team-dev"
         "vue-best-practices"
         "nuxt"


### PR DESCRIPTION
## Summary

- Remove `agent-browser` input from `flake.nix`
- Remove `agent-browser` source from `programs/agent-skills/default.nix`
- Remove `agent-browser` from the enabled skills list

## Test plan

- [x] Run `nix flake update` to verify flake.lock updates correctly
- [x] Run `home-manager switch` to verify the configuration applies without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed agent-browser component and its associated configuration from the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->