### PR TITLE
feat: add apm (Agent Package Manager) to nix packages

### DIFF
--- a/config/nix/flake.nix
+++ b/config/nix/flake.nix
@@ -103,7 +103,12 @@
             mcp-servers-nix.homeManagerModules.default
           ];
           extraSpecialArgs = {
-            inherit inputs nodePkgs username apm;
+            inherit
+              inputs
+              nodePkgs
+              username
+              apm
+              ;
           };
         };
       mkNixosConfig =
@@ -123,7 +128,12 @@
               home-manager.useUserPackages = true;
               home-manager.users.${username} = import ./home.nix;
               home-manager.extraSpecialArgs = {
-                inherit inputs nodePkgs username apm;
+                inherit
+                  inputs
+                  nodePkgs
+                  username
+                  apm
+                  ;
               };
               home-manager.sharedModules = [
                 agent-skills-nix.homeManagerModules.default

--- a/config/nix/flake.nix
+++ b/config/nix/flake.nix
@@ -56,6 +56,7 @@
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
       nodePkgs = import ../node2nix/default.nix { inherit pkgs; };
+      apm = pkgs.callPackage ./pkgs/apm.nix { };
       lintApp = pkgs.writeShellApplication {
         name = "lint";
         runtimeInputs = [
@@ -102,7 +103,7 @@
             mcp-servers-nix.homeManagerModules.default
           ];
           extraSpecialArgs = {
-            inherit inputs nodePkgs username;
+            inherit inputs nodePkgs username apm;
           };
         };
       mkNixosConfig =
@@ -122,7 +123,7 @@
               home-manager.useUserPackages = true;
               home-manager.users.${username} = import ./home.nix;
               home-manager.extraSpecialArgs = {
-                inherit inputs nodePkgs username;
+                inherit inputs nodePkgs username apm;
               };
               home-manager.sharedModules = [
                 agent-skills-nix.homeManagerModules.default

--- a/config/nix/home.nix
+++ b/config/nix/home.nix
@@ -5,6 +5,7 @@
   nodePkgs,
   inputs,
   username,
+  apm,
   ...
 }:
 
@@ -38,6 +39,7 @@
     curl # HTTP client
     lsof # List open files
     pandoc # Document format converter
+    apm
     nodePkgs."agent-browser"
     nodePkgs."ccmanager"
     nodePkgs."@vue/language-server"

--- a/config/nix/pkgs/apm.nix
+++ b/config/nix/pkgs/apm.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+  lib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "apm";
+  version = "0.8.12";
+
+  src = fetchurl {
+    url = "https://github.com/microsoft/apm/releases/download/v${version}/apm-linux-x86_64.tar.gz";
+    hash = "sha256-WMiLwFHQ8JranYh1G4c8gm1Wt2KsL7+KvUAy3OOOazk=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ openssl ];
+
+  unpackPhase = ''
+    tar -xzf $src
+  '';
+
+  installPhase = ''
+    mkdir -p $out/libexec/apm $out/bin
+    cp -r apm-linux-x86_64/* $out/libexec/apm/
+    chmod +x $out/libexec/apm/apm
+    ln -s $out/libexec/apm/apm $out/bin/apm
+  '';
+
+  meta = {
+    description = "Agent Package Manager - dependency manager for AI agents";
+    homepage = "https://github.com/microsoft/apm";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary

- Add `config/nix/pkgs/apm.nix` as a custom derivation for Microsoft's Agent Package Manager (apm v0.8.12)
- Wire `apm` through `flake.nix` `extraSpecialArgs` for both home-manager standalone and NixOS module configurations
- Add `apm` to `home.nix` packages list

## Test plan

- [x] `nix run ./config/nix#lint` passes
- [x] `nix run ./config/nix#fmt` passes
- [x] `nix run ./config/nix#test` passes
- [x] `apm` binary is available after `home-manager switch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated APM (Application Performance Monitoring) tool version 0.8.12 into the development environment to provide comprehensive application performance monitoring and analysis capabilities.

* **Chores**
  * Updated development environment configuration to automatically include and initialize the APM tool, ensuring seamless availability across all development workflows without requiring additional setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->