### PR TITLE
feat: add create-branch skill for interactive branch creation

### DIFF
--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -139,6 +139,7 @@
     skills = {
       "org-flow:create-issue" = ./skills/org-flow/create-issue;
       "team-dev" = ./skills/team-dev;
+      "commit-commands:create-branch" = ./skills/commit-commands/create-branch;
     };
 
     context = ./CLAUDE.md;

--- a/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
+++ b/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
@@ -35,9 +35,12 @@ description: ブランチを作成するスキル。feat, fix, chore等の一般
 
 ### 3. prefixを確定する
 
+確定した値を `PREFIX` 変数に格納する。
+
 - ユーザーが「custom」を選択した場合: `AskUserQuestion` で自由入力させる
   - 質問: 「カスタムprefixを入力してください（例: hotfix, spike, wip）」
-- それ以外: 選択されたprefixをそのまま使用する
+  - 入力値を `PREFIX` に格納する
+- それ以外: 選択された値を `PREFIX` に格納する
 
 ### 4. ブランチ説明を確定する
 
@@ -57,13 +60,13 @@ BRANCH_DESC=$(printf '%s' "$ENGLISH_TITLE" \
 - 「ログイン機能追加」 → `add-login-feature`
 - 「認証エラー修正」 → `fix-auth-error`
 
-ブランチ名は `{prefix}/{BRANCH_DESC}` の形式にする。
+ブランチ名は `${PREFIX}/${BRANCH_DESC}` の形式にする。
 
 ### 5. 現在のブランチを確認してブランチを作成する
 
 ```bash
 CURRENT_BRANCH=$(git branch --show-current)
-NEW_BRANCH="{prefix}/{BRANCH_DESC}"
+NEW_BRANCH="${PREFIX}/${BRANCH_DESC}"
 git checkout -b "$NEW_BRANCH"
 ```
 

--- a/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
+++ b/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
@@ -20,7 +20,7 @@ description: ブランチを作成するスキル。feat, fix, chore等の一般
 
 - 質問: 「ブランチのprefixを選択してください」
 - 選択肢 (options フィールドに配列で渡す):
-  - `feat` — 新機能
+  - `feature` — 新機能
   - `fix` — バグ修正
   - `chore` — 雑務・設定変更
   - `docs` — ドキュメント

--- a/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
+++ b/nix/programs/claude-code/skills/commit-commands/create-branch/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: commit-commands:create-branch
+description: ブランチを作成するスキル。feat, fix, chore等の一般的なprefixを選択するか、カスタムprefixを自由入力し、現在のブランチから新しいブランチを作成する。「ブランチを作って」「新しいブランチ」「create branch」「/create-branch」「branch作成」などで使用。
+---
+
+# commit-commands:create-branch: ブランチ作成スキル
+
+現在のブランチから、prefix付きの新しいブランチを作成します。
+
+## 手順
+
+### 1. 引数を確認する
+
+`$ARGUMENTS` が指定されている場合はそれをブランチの説明（タイトル）として使用し、ステップ2へ進む。
+指定されていない場合はステップ2でprefixを選択した後、ステップ4でタイトルを入力させる。
+
+### 2. prefixをAskUserQuestionで選択する
+
+`AskUserQuestion` ツールを使い、以下の選択肢を提示する:
+
+- 質問: 「ブランチのprefixを選択してください」
+- 選択肢 (options フィールドに配列で渡す):
+  - `feat` — 新機能
+  - `fix` — バグ修正
+  - `chore` — 雑務・設定変更
+  - `docs` — ドキュメント
+  - `refactor` — リファクタリング
+  - `test` — テスト追加・修正
+  - `style` — コードスタイル（ロジック変更なし）
+  - `perf` — パフォーマンス改善
+  - `ci` — CI/CD
+  - `build` — ビルド関連
+  - `revert` — リバート
+  - `custom` — カスタム入力
+
+### 3. prefixを確定する
+
+- ユーザーが「custom」を選択した場合: `AskUserQuestion` で自由入力させる
+  - 質問: 「カスタムprefixを入力してください（例: hotfix, spike, wip）」
+- それ以外: 選択されたprefixをそのまま使用する
+
+### 4. ブランチ説明を確定する
+
+- `$ARGUMENTS` が指定されていた場合: その値をタイトルとして使用し、このステップはスキップする
+- 指定されていない場合: `AskUserQuestion` でタイトルを入力させる
+  - 質問: 「ブランチ名の説明を入力してください（日本語可、例: ログイン機能追加）」
+
+タイトルが日本語の場合はまず英語に翻訳する（あなた自身が翻訳する。外部ツールは不要）。
+翻訳した英語をkebab-caseに正規化する:
+```bash
+BRANCH_DESC=$(printf '%s' "$ENGLISH_TITLE" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g; s/-{2,}/-/g')
+```
+
+例:
+- 「ログイン機能追加」 → `add-login-feature`
+- 「認証エラー修正」 → `fix-auth-error`
+
+ブランチ名は `{prefix}/{BRANCH_DESC}` の形式にする。
+
+### 5. 現在のブランチを確認してブランチを作成する
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+NEW_BRANCH="{prefix}/{BRANCH_DESC}"
+git checkout -b "$NEW_BRANCH"
+```
+
+作成に成功したら「ブランチ `{新しいブランチ名}` を `{現在のブランチ}` から作成しました」と報告する。
+エラーが発生した場合はエラーメッセージを表示し、原因を説明する。


### PR DESCRIPTION
## Summary

- Add `commit-commands:create-branch` skill to `nix/programs/claude-code/skills/commit-commands/create-branch/`
- Register the skill in `nix/programs/claude-code/default.nix`
- Supports selecting a prefix interactively (feat/fix/chore/docs/refactor/test/style/perf/ci/build/revert/custom)
- Accepts a Japanese or English title as `$ARGUMENTS`, translating Japanese to kebab-case English automatically

## Test plan

- [x] Run `home-manager switch` to apply the skill
- [x] Invoke `/create-branch` without arguments and verify prefix selection + title input prompt
- [x] Invoke `/create-branch ログイン機能追加` and verify prefix selection only, then branch creation with translated name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new skill for creating git branches with standardized naming conventions. Users can select a commit-prefix from predefined options or enter a custom one, provide a branch description, and automatically generate kebab-case branch names. Japanese descriptions are automatically translated to English before formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->