### PR TITLE
feat: add Python 3 support with uv configuration

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -17,7 +17,6 @@
 
   home.packages = with pkgs; [
     fnm # Fast Node Manager
-    uv # Python package manager
     zoxide # Smart cd replacement
     fzf # Fuzzy finder
     ripgrep # Fast grep alternative
@@ -49,6 +48,7 @@
     ./programs/aws
     ./programs/wezterm
     ./programs/sheldon
+    ./programs/python
   ];
 
   home.sessionVariables = { };

--- a/nix/programs/python/default.nix
+++ b/nix/programs/python/default.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    python3
+    uv
+  ];
+
+  home.sessionVariables = {
+    UV_PYTHON_PREFERENCE = "only-system";
+    UV_PYTHON = "3.13";
+  };
+}


### PR DESCRIPTION
## Summary

- Add `nix/programs/python` module with `python3` and `uv` packages
- Move `uv` from top-level `home.packages` in `home.nix` to the new python module
- Set `UV_PYTHON=3.13` to pin default Python to the latest stable version
- Set `UV_PYTHON_PREFERENCE=only-system` to use the Nix-managed Python interpreter

## Test plan

- [x] Verify `python3 --version` returns `Python 3.13.x`
- [x] Verify `uv python list` shows the Nix-managed Python 3.13 as installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated Python environment configuration module for better organization.
  * Added Python 3.13 as the targeted version for development.

* **Chores**
  * Reorganized Python tooling package management into a dedicated configuration module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->