### PR TITLE
chore: remove default sonnet model from claude-code settings

### DIFF
--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -82,7 +82,6 @@
 
     # settings.json
     settings = {
-      model = "sonnet";
       effortLevel = "xhigh";
       includeCoAuthoredBy = false;
       teammateMode = "in-process";


### PR DESCRIPTION
## Summary

- Remove `model = "sonnet"` from `nix/programs/claude-code/default.nix` settings

## Test plan

- [x] Verify lint, fmt, and test pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Claude Code default model configuration to remove explicit model specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->