### PR TITLE
chore: remove nixos MCP server from claude-code config

### DIFF
--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -7,7 +7,6 @@
 {
   mcp-servers.programs = {
     context7.enable = true;
-    nixos.enable = true;
     terraform.enable = true;
   };
 


### PR DESCRIPTION
## Summary
- Remove `nixos.enable = true` from the claude-code MCP servers configuration

## Test plan
- [ ] Verify claude-code builds without the nixos MCP server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the nixos MCP server integration while keeping context7 and terraform MCP servers active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->