### PR TITLE
feat: add custom claude-code derivation with linux-x64 native binary

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -54,9 +54,13 @@
     }:
     let
       system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
       nodePkgs = import ./node2nix/default.nix { inherit pkgs; };
       apm = pkgs.callPackage ./pkgs/apm.nix { };
+      claudeCode = pkgs.callPackage ./pkgs/claude-code.nix { };
       lintApp = pkgs.writeShellApplication {
         name = "lint";
         runtimeInputs = [
@@ -108,6 +112,7 @@
               nodePkgs
               username
               apm
+              claudeCode
               ;
           };
         };
@@ -133,6 +138,7 @@
                   nodePkgs
                   username
                   apm
+                  claudeCode
                   ;
               };
               home-manager.sharedModules = [

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -6,6 +6,7 @@
   inputs,
   username,
   apm,
+  claudeCode,
   ...
 }:
 

--- a/nix/node2nix/node-packages.nix
+++ b/nix/node2nix/node-packages.nix
@@ -1675,10 +1675,10 @@ in
   "@anthropic-ai/claude-code" = nodeEnv.buildNodePackage {
     name = "_at_anthropic-ai_slash_claude-code";
     packageName = "@anthropic-ai/claude-code";
-    version = "2.1.119";
+    version = "2.1.121";
     src = fetchurl {
-      url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.119.tgz";
-      sha512 = "gt9dxiIQU60eWcSM26fwu31vzLeL1NYwY3HDFby1TipzwF5lNY766DEqKLkGemZGxaAOXKe9nY3c8GQK/gQ7VA==";
+      url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.121.tgz";
+      sha512 = "23XFtlyWF8eLlNbZTYsTHTFeqH7d8tPBWoJ0N5cF7+AQ4yI3HHgX/LX3keChksUEX/LnWB+P3wL7GjonTSJXxA==";
     };
     buildInputs = globalBuildInputs;
     meta = {

--- a/nix/pkgs/claude-code.nix
+++ b/nix/pkgs/claude-code.nix
@@ -1,0 +1,58 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+}:
+
+let
+  mainTgz = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.121.tgz";
+    sha512 = "23XFtlyWF8eLlNbZTYsTHTFeqH7d8tPBWoJ0N5cF7+AQ4yI3HHgX/LX3keChksUEX/LnWB+P3wL7GjonTSJXxA==";
+  };
+  nativeTgz = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.121.tgz";
+    sha512 = "vTvPoq0to7KKEiOZ+2nyo4nlcNlVeLqo1kgAkbRd1i7ytC2KiqgLbZ2GbTtGhe2M4uWWgurKEf9CWIt6SCnYkw==";
+  };
+in
+stdenv.mkDerivation {
+  pname = "claude-code";
+  version = "2.1.121";
+
+  dontUnpack = true;
+  # Node.js SEA binaries embed the JS application in a custom ELF section.
+  # strip and patchelf both corrupt this blob, so both must be disabled.
+  # nix-ld handles dynamic linking on this NixOS system.
+  dontStrip = true;
+  dontPatchELF = true;
+
+  installPhase = ''
+    # Extract main npm package
+    mkdir -p main-pkg
+    tar xzf ${mainTgz} -C main-pkg --strip-components=1
+
+    # Extract linux-x64 native binary and replace the placeholder
+    mkdir -p native-pkg
+    tar xzf ${nativeTgz} -C native-pkg --strip-components=1
+    cp native-pkg/claude main-pkg/bin/claude.exe
+    chmod +x main-pkg/bin/claude.exe
+
+    # Install package files
+    mkdir -p $out/lib/node_modules/@anthropic-ai/claude-code
+    cp -r main-pkg/* $out/lib/node_modules/@anthropic-ai/claude-code/
+
+    # Create .bin symlink structure matching node2nix layout
+    mkdir -p $out/lib/node_modules/.bin
+    ln -s ../@anthropic-ai/claude-code/bin/claude.exe $out/lib/node_modules/.bin/claude
+
+    # bin -> lib/node_modules/.bin symlink (node2nix convention)
+    ln -s lib/node_modules/.bin $out/bin
+  '';
+
+  meta = {
+    description = "Use Claude, Anthropic's AI assistant, right from your terminal.";
+    homepage = "https://github.com/anthropics/claude-code";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "claude";
+  };
+}

--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -1,6 +1,6 @@
 {
-  nodePkgs,
   inputs,
+  claudeCode,
   ...
 }:
 
@@ -19,7 +19,7 @@
 
   programs.claude-code = {
     enable = true;
-    package = nodePkgs."@anthropic-ai/claude-code";
+    package = claudeCode;
     enableMcpIntegration = true;
 
     # Plugins (from anthropics/claude-code repository)


### PR DESCRIPTION
## Summary

- Add `nix/pkgs/claude-code.nix`: custom derivation that fetches `@anthropic-ai/claude-code` and `@anthropic-ai/claude-code-linux-x64`, installs the native binary in place of the placeholder stub
- Wire new derivation through `flake.nix`, `home.nix`, and `programs/claude-code/default.nix`, replacing the node2nix package
- Update to version 2.1.121

## Background

Versions 2.1.114+ switched from a Node.js script (`cli.js`) to a native binary. The `@anthropic-ai/claude-code-linux-x64` optional dependency is not included by node2nix, so the CLI was broken.

Node.js SEA binaries embed the JS application in a custom ELF section — `strip` and `patchelf` both corrupt this blob. `dontStrip = true` and `dontPatchELF = true` are set; `nix-ld` handles dynamic linking on this NixOS system.

## Test plan

- [x] `claude --version` returns `2.1.121 (Claude Code)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Code package to version 2.1.121
  * Reorganized package configuration to improve system integration and dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->