### PR TITLE
feat: add sidekick.nvim plugin

### DIFF
--- a/nix/programs/neovim/nvim/lazy-lock.json
+++ b/nix/programs/neovim/nvim/lazy-lock.json
@@ -55,6 +55,7 @@
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "quick-scope": { "branch": "master", "commit": "6cee1d9e0b9ac0fbffeb538d4a5ba9f5628fabbc" },
   "rest.nvim": { "branch": "main", "commit": "714d5512aaec5565d55652480c16c26f8d95645d" },
+  "sidekick.nvim": { "branch": "main", "commit": "53a2d3afa61e5fd2e17b270b5fa72e5493808304" },
   "sqlite.lua": { "branch": "master", "commit": "50092d60feb242602d7578398c6eb53b4a8ffe7b" },
   "telescope-file-browser.nvim": { "branch": "master", "commit": "3610dc7dc91f06aa98b11dca5cc30dfa98626b7e" },
   "telescope-frecency.nvim": { "branch": "master", "commit": "fc6418bf663a182b72427487246b870f2ddbbbe2" },

--- a/nix/programs/neovim/nvim/plugins.lua
+++ b/nix/programs/neovim/nvim/plugins.lua
@@ -46,6 +46,7 @@ require("lazy").setup({
 	require("plugins.package-info").config(),
 	require("plugins.pathtool").config(),
 	require("plugins.rest").config(),
+	require("plugins.sidekick").config(),
 	require("plugins.telescope").config(),
 	require("plugins.todo-comments").config(),
 	require("plugins.toggleterm").config(),

--- a/nix/programs/neovim/nvim/plugins/plugin_spec_spec.lua
+++ b/nix/programs/neovim/nvim/plugins/plugin_spec_spec.lua
@@ -152,6 +152,7 @@ local lazy_plugin_files = {
 	"plenary",
 	"quick-scope",
 	"rest",
+	"sidekick",
 	"sqlite",
 	"telescope",
 	"telescope-file-browser",

--- a/nix/programs/neovim/nvim/plugins/sidekick/init.lua
+++ b/nix/programs/neovim/nvim/plugins/sidekick/init.lua
@@ -1,0 +1,71 @@
+local sidekick = {}
+
+function sidekick.config()
+	return {
+		"folke/sidekick.nvim",
+		event = "VeryLazy",
+		opts = {
+			cli = {
+				mux = {
+					backend = "tmux",
+					enabled = true,
+				},
+			},
+		},
+		keys = {
+			{
+				"<tab>",
+				function()
+					if not require("sidekick").nes_jump_or_apply() then
+						return "<Tab>"
+					end
+				end,
+				expr = true,
+				desc = "Goto/Apply Next Edit Suggestion",
+			},
+			{
+				"<leader>aa",
+				function()
+					require("sidekick.cli").toggle({
+						name = "claude",
+						focus = true,
+					})
+				end,
+				desc = "Sidekick Toggle Claude",
+			},
+			{
+				"<leader>at",
+				function()
+					require("sidekick.cli").send({ msg = "{this}" })
+				end,
+				mode = { "x", "n" },
+				desc = "Send This",
+			},
+			{
+				"<leader>af",
+				function()
+					require("sidekick.cli").send({ msg = "{file}" })
+				end,
+				desc = "Send File",
+			},
+			{
+				"<leader>av",
+				function()
+					require("sidekick.cli").send({ msg = "{selection}" })
+				end,
+				mode = { "x" },
+				desc = "Send Visual Selection",
+			},
+			{
+				"<leader>ap",
+				function()
+					require("sidekick.cli").prompt()
+				end,
+				mode = { "n", "x" },
+				desc = "Sidekick Select Prompt",
+			},
+		},
+	}
+end
+
+return sidekick


### PR DESCRIPTION
## Summary
- Add `folke/sidekick.nvim` plugin with Claude CLI integration via tmux mux backend
- Wire up keybindings under `<leader>a*` for toggling, sending text/file/selection, and prompt picker
- Bind `<Tab>` to jump/apply next edit suggestion (NES)

## Test plan
- [x] `nix run ./nix#lint`
- [x] `nix run ./nix#fmt`
- [x] `nix run ./nix#test`
- [x] Launch Neovim and verify sidekick loads on `VeryLazy`
- [x] Verify `<leader>aa` toggles the Claude sidekick window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Sidekick plugin for Neovim with tmux support for AI-assisted code suggestions and navigation
  * Added keybindings: jump/apply suggestions (`<Tab>`), toggle Claude focus session (`<leader>aa`), and quick templated messages for common code assistance tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->