### PR TITLE
feat(orgmode): add id_get_or_create action and include wiki in org-roam

### DIFF
--- a/nix/programs/neovim/nvim/plugins/org-roam/init.lua
+++ b/nix/programs/neovim/nvim/plugins/org-roam/init.lua
@@ -13,6 +13,7 @@ function orgRoam.config()
 				directory = "~/ghq/github.com/mikinovation/org/roam",
 				org_files = {
 					"~/ghq/github.com/mikinovation/org",
+					"~/ghq/github.com/mikinovation/mikinovation/wiki/data",
 				},
 			})
 		end,

--- a/nix/programs/neovim/nvim/plugins/orgmode/actions.lua
+++ b/nix/programs/neovim/nvim/plugins/orgmode/actions.lua
@@ -158,6 +158,16 @@ function M.copy_as_markdown()
 	vim.notify("Copied as Markdown", vim.log.levels.INFO)
 end
 
+--- Insert/ensure an :ID: property on the closest org heading.
+function M.id_get_or_create()
+	local headline = require("orgmode.api").current():get_closest_headline()
+	if not headline then
+		vim.notify("No heading at cursor", vim.log.levels.WARN)
+		return
+	end
+	headline:id_get_or_create()
+end
+
 --- Open a terminal in the left tmux pane at the heading's :DIR:.
 function M.open_terminal_pane()
 	local dir = resolve_dir()

--- a/nix/programs/neovim/nvim/plugins/orgmode/init.lua
+++ b/nix/programs/neovim/nvim/plugins/orgmode/init.lua
@@ -37,6 +37,7 @@ function orgmode.config()
 					org = {
 						org_global_cycle = "<leader>zz",
 						org_open_at_point = "<CR>",
+						org_clock_in = false,
 					},
 				},
 			})

--- a/nix/programs/neovim/nvim/plugins/orgmode/keymaps.lua
+++ b/nix/programs/neovim/nvim/plugins/orgmode/keymaps.lua
@@ -14,6 +14,7 @@ function M.setup()
 			local function bopts(desc)
 				return { buffer = ev.buf, desc = desc }
 			end
+			map("n", "<leader>oxi", actions.id_get_or_create, bopts("Insert :ID: on closest heading"))
 			map("n", "<leader>ov", actions.open_nvim_pane, bopts("Open nvim in left tmux pane at :DIR:"))
 			map("n", "<leader>oC", actions.resume_claude_session, bopts("Resume Claude session in right tmux pane"))
 			map("v", "<leader>op", actions.send_prompt_to_claude, bopts("Send selection to Claude Code"))


### PR DESCRIPTION
## Summary
- Add `id_get_or_create` action bound to `<leader>oxi` to insert/ensure `:ID:` on the closest org heading
- Disable the default `org_clock_in` mapping to free up the binding
- Include `~/ghq/github.com/mikinovation/mikinovation/wiki/data` in org-roam `org_files` so wiki notes participate in the roam graph

## Test plan
- [x] Open an org file, place cursor on a heading, press `<leader>oxi` and confirm an `:ID:` property is inserted
- [x] Re-run on the same heading and confirm the existing ID is preserved (no duplicate)
- [x] Verify org-roam picks up files under `mikinovation/wiki/data`
- [x] `nix run ./nix#lint && nix run ./nix#fmt && nix run ./nix#test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut to automatically insert unique ID properties on org-mode headings, improving note organization and cross-referencing capabilities

* **Configuration**
  * Expanded org-roam file scanning to include an additional wiki directory path
  * Disabled clock-in tracking by default in org-mode plugin

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mikinovation/dotfiles/pull/432)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->