### PR TITLE
feat: add typst environment and Noto fonts with CJK/emoji support

### DIFF
--- a/nix/home.nix
+++ b/nix/home.nix
@@ -50,6 +50,7 @@
     ./programs/wezterm
     ./programs/sheldon
     ./programs/python
+    ./programs/typst
   ];
 
   home.sessionVariables = { };

--- a/nix/nixos/configuration.nix
+++ b/nix/nixos/configuration.nix
@@ -59,6 +59,14 @@
     wget
   ];
 
+  # System fonts
+  fonts.packages = with pkgs; [
+    noto-fonts
+    noto-fonts-cjk-sans
+    noto-fonts-cjk-serif
+    noto-fonts-color-emoji
+  ];
+
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It's perfectly fine and recommended to leave

--- a/nix/programs/neovim/nvim/lsp/servers/init.lua
+++ b/nix/programs/neovim/nvim/lsp/servers/init.lua
@@ -11,8 +11,10 @@ require("lsp.servers.typescript")(capabilities)
 require("lsp.servers.tailwindcss")(capabilities)
 require("lsp.servers.solargraph")(capabilities)
 require("lsp.servers.nil_ls")(capabilities)
+require("lsp.servers.tinymist")(capabilities)
 
 -- Enable all configured LSP servers
-local enabled_servers = { "lua_ls", "rust_analyzer", "tsgo", "vtsls", "vue_ls", "tailwindcss", "solargraph", "nil_ls" }
+local enabled_servers =
+	{ "lua_ls", "rust_analyzer", "tsgo", "vtsls", "vue_ls", "tailwindcss", "solargraph", "nil_ls", "tinymist" }
 
 vim.lsp.enable(enabled_servers)

--- a/nix/programs/neovim/nvim/lsp/servers/tinymist.lua
+++ b/nix/programs/neovim/nvim/lsp/servers/tinymist.lua
@@ -1,0 +1,15 @@
+-- lsp/servers/tinymist.lua
+
+return function(capabilities)
+	vim.lsp.config.tinymist = {
+		cmd = { "tinymist" },
+		filetypes = { "typst" },
+		root_markers = { "typst.toml", ".git" },
+		capabilities = capabilities,
+		settings = {
+			exportPdf = "onSave",
+			formatterMode = "typstyle",
+			semanticTokens = "enable",
+		},
+	}
+end

--- a/nix/programs/neovim/nvim/lsp/servers_spec.lua
+++ b/nix/programs/neovim/nvim/lsp/servers_spec.lua
@@ -27,6 +27,7 @@ describe("lsp servers", function()
 			"tailwindcss",
 			"solargraph",
 			"nil_ls",
+			"tinymist",
 		}
 
 		it("has no unexpected servers", function()

--- a/nix/programs/neovim/nvim/plugins/nvim-treesitter/init.lua
+++ b/nix/programs/neovim/nvim/plugins/nvim-treesitter/init.lua
@@ -17,6 +17,7 @@ function nvimTreesitter.config()
 				"markdown",
 				"markdown_inline",
 				"query",
+				"typst",
 				"vim",
 				"vimdoc",
 			}

--- a/nix/programs/typst/default.nix
+++ b/nix/programs/typst/default.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    typst
+    tinymist
+    typstyle
+    typst-live
+  ];
+}


### PR DESCRIPTION
## Summary
- Add typst environment with tinymist LSP for typst document authoring
- Add Noto fonts package with full CJK and emoji support to NixOS configuration

## Test plan
- [x] Verify tinymist LSP starts in `.typ` files
- [x] Confirm CJK and emoji glyphs render correctly in applications
- [x] Run `nix run ./nix#lint && nix run ./nix#fmt && nix run ./nix#test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Typst language support with LSP integration for enhanced editing experience.
  * Installed Noto fonts including CJK and emoji variants for improved system typography.
  * Included Typst development tools (tinymist, typstyle, typst-live).

* **Tests**
  * Extended test coverage for language server configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mikinovation/dotfiles/pull/433)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->