### PR TITLE
chore(claude-code): harden settings with hard_deny and PreCompact hook

### DIFF
--- a/nix/programs/claude-code/default.nix
+++ b/nix/programs/claude-code/default.nix
@@ -107,6 +107,17 @@
             ];
           }
         ];
+        PreCompact = [
+          {
+            matcher = "";
+            hooks = [
+              {
+                type = "command";
+                command = "$HOME/ghq/github.com/mikinovation/dotfiles/nix/programs/claude-code/hooks/pre-compact.sh";
+              }
+            ];
+          }
+        ];
       };
       statusLine = {
         type = "command";
@@ -115,7 +126,8 @@
       env = {
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
         CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
-        DISABLE_AUTOUPDATER = "1";
+        DISABLE_UPDATES = "1";
+        CLAUDE_CODE_STOP_HOOK_BLOCK_CAP = "5";
       };
       permissions = {
         defaultMode = "bypassPermissions";
@@ -132,6 +144,18 @@
           "Bash(git fetch *)"
         ];
       };
+      autoMode.hard_deny = [
+        "Bash(rm -rf /*)"
+        "Bash(rm -rf ~*)"
+        "Bash(rm -rf $HOME*)"
+        "Bash(rm -rf .*)"
+        "Bash(git push --force*)"
+        "Bash(git push -f*)"
+        "Bash(git reset --hard*)"
+        "Bash(dd if=*)"
+        "Bash(mkfs*)"
+        "Bash(chmod -R 777*)"
+      ];
     };
 
     skills = {

--- a/nix/programs/claude-code/hooks/pre-compact.sh
+++ b/nix/programs/claude-code/hooks/pre-compact.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# PreCompact hook: record context compaction events.
+
+LOG_DIR="$HOME/.claude/compact-logs"
+mkdir -p "$LOG_DIR"
+
+SESSION_ID="${CLAUDE_CODE_SESSION_ID:-unknown}"
+TIMESTAMP="$(date -Iseconds)"
+
+printf '[%s] compact session=%s cwd=%s\n' \
+  "$TIMESTAMP" "$SESSION_ID" "$PWD" \
+  >> "$LOG_DIR/compact.log"


### PR DESCRIPTION
## Summary
- Add `autoMode.hard_deny` to absolutely block destructive operations (`rm -rf /`, `git push --force`, `git reset --hard`, `dd`, `mkfs`, `chmod -R 777`) while keeping `bypassPermissions` for ergonomics
- Migrate `DISABLE_AUTOUPDATER` → `DISABLE_UPDATES` (newer env var that also blocks manual updates, appropriate for nix-managed binary)
- Add `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP=5` to prevent Stop hook runaway loops
- Add `PreCompact` hook that records context compaction events to `~/.claude/compact-logs/compact.log` for later inspection

## Test plan
- [x] `nix run ./nix#lint && nix run ./nix#fmt && nix run ./nix#test` all pass
- [x] `nix flake check` reports all checks passed
- [x] `home-manager switch` and verify generated `~/.claude/settings.json` contains the new fields
- [x] Trigger a context compaction and confirm `~/.claude/compact-logs/compact.log` receives an entry
- [x] Attempt a blocked command (e.g. `git push --force`) and confirm it is denied