### PR TITLE
chore(nix): update claude-code to 2.1.175

### DIFF
--- a/nix/pkgs/claude-code.nix
+++ b/nix/pkgs/claude-code.nix
@@ -6,17 +6,17 @@
 
 let
   mainTgz = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.168.tgz";
-    sha512 = "4NRDjZZJa8VbHm4emoZ87G3EEz2itIyKAmQgimWMmg9eaQwIewYA7lcgPEGfCfPd17bkzRrKOMA9puP3EFNMcA==";
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.175.tgz";
+    sha512 = "x37KEw7T1vz/CLkpLYqa8d6eyS/R1777+HMYJRqYf4e5+OhZwF/+d1LoTs5vFXTrFCWFjZTbWGZksW/gKpvCTQ==";
   };
   nativeTgz = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.168.tgz";
-    sha512 = "y3pQEBNAePKR6PDXqF7qRw1nP7CokRVdrDu4yfCncD3nI8wNwOSMBEgw/n/TP9c9K8riQgHYx2XzjEhPfyptjQ==";
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.175.tgz";
+    sha512 = "RegEK8Cdj5tM2ZiePk887o+OwwfibR5jxI2yh3z0aKtelFH63kM2TZEGvroj5iCsKP33LMK3kFKwBD4gJ3d1LQ==";
   };
 in
 stdenv.mkDerivation {
   pname = "claude-code";
-  version = "2.1.168";
+  version = "2.1.175";
 
   dontUnpack = true;
   # Node.js SEA binaries embed the JS application in a custom ELF section.


### PR DESCRIPTION
## Summary
- claude-code を 2.1.168 から 2.1.175 に更新

## Test plan
- [x] `nix build --no-link ./nix#checks.x86_64-linux.home-manager-build` ok
- [x] `nix run ./nix#lint` (luacheck) ok
- [x] `nix run ./nix#fmt` ok
- [x] `nix run ./nix#test` ok (384 successes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated claude-code package to version 2.1.175, including updated download sources and verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->